### PR TITLE
reverse logic for errorOnYellow

### DIFF
--- a/cohort-elastic/src/main/kotlin/com/sksamuel/cohort/elastic/ElasticClusterHealthCheck.kt
+++ b/cohort-elastic/src/main/kotlin/com/sksamuel/cohort/elastic/ElasticClusterHealthCheck.kt
@@ -37,8 +37,8 @@ class ElasticClusterHealthCheck(
         ClusterHealthStatus.RED -> HealthCheckResult.Unhealthy(msg, null)
         ClusterHealthStatus.GREEN -> HealthCheckResult.Healthy(msg)
         ClusterHealthStatus.YELLOW -> when (errorOnYellow) {
-          true -> HealthCheckResult.Healthy(msg)
-          false -> HealthCheckResult.Unhealthy(msg, null)
+          false -> HealthCheckResult.Healthy(msg)
+          true -> HealthCheckResult.Unhealthy(msg, null)
         }
       }
 


### PR DESCRIPTION
The `errorOnYellow` flag logic in ElasticClusterHealthCheck was backwards, so this just reverses it.