### PR TITLE
Add coroutine driver support for mongodb

### DIFF
--- a/cohort-mongo/build.gradle.kts
+++ b/cohort-mongo/build.gradle.kts
@@ -1,8 +1,10 @@
 dependencies {
    implementation(projects.cohortApi)
    compileOnly(libs.mongodb.driver.sync)
+   compileOnly(libs.mongodb.driver.coroutine)
    testImplementation(libs.testcontainers.mongodb)
    testImplementation(libs.mongodb.driver.sync)
+   testImplementation(libs.mongodb.driver.coroutine)
 }
 
 apply("../publish.gradle.kts")

--- a/cohort-mongo/src/main/kotlin/com/sksamuel/cohort/mongo/MongoConnectionHealthCheck.kt
+++ b/cohort-mongo/src/main/kotlin/com/sksamuel/cohort/mongo/MongoConnectionHealthCheck.kt
@@ -3,6 +3,7 @@ package com.sksamuel.cohort.mongo
 import com.mongodb.client.MongoClient
 import com.sksamuel.cohort.HealthCheck
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runInterruptible
 
 class MongoConnectionHealthCheck private constructor(
@@ -18,5 +19,14 @@ class MongoConnectionHealthCheck private constructor(
             client.listDatabaseNames().toList()
          }
       }
+   )
+
+   constructor(
+      client: com.mongodb.kotlin.client.coroutine.MongoClient,
+      name: String = "mongo_connection",
+   ) : this(
+      GenericMongoConnectionHealthCheck(name) {
+         client.listDatabaseNames().toList()
+      },
    )
 }

--- a/cohort-mongo/src/test/kotlin/com/sksamuel/cohort/mongo/MongoConnectionHealthCheckTest.kt
+++ b/cohort-mongo/src/test/kotlin/com/sksamuel/cohort/mongo/MongoConnectionHealthCheckTest.kt
@@ -1,6 +1,7 @@
 package com.sksamuel.cohort.mongo
 
 import com.mongodb.client.MongoClients
+import com.mongodb.kotlin.client.coroutine.MongoClient
 import com.sksamuel.cohort.HealthCheckResult
 import io.kotest.core.extensions.install
 import io.kotest.core.spec.style.FunSpec
@@ -11,17 +12,30 @@ import org.testcontainers.utility.DockerImageName
 
 class MongoConnectionHealthCheckTest : FunSpec({
 
-  val container = MongoDBContainer(DockerImageName.parse("mongo:4.0.10"))
-  install(TestContainerExtension(container))
+   val container = MongoDBContainer(DockerImageName.parse("mongo:4.0.10"))
+   install(TestContainerExtension(container))
 
-  test("mongo health check should connect to mongo") {
-    val client = MongoClients.create(container.connectionString)
-    MongoConnectionHealthCheck(client).check() shouldBe HealthCheckResult.healthy("Connected to mongo instance (3 databases)")
-  }
+   test("mongo health check should connect to mongo") {
+      val client = MongoClients.create(container.connectionString)
+      MongoConnectionHealthCheck(
+         client,
+      ).check() shouldBe HealthCheckResult.healthy("Connected to mongo instance (3 databases)")
+   }
 
-  test("mongo health check should fail if cannot connect") {
-    val client = MongoClients.create("mongodb://localhost:11111")
-    MongoConnectionHealthCheck(client).check().message.shouldBe("Could not connect to mongo instance")
-  }
+   test("mongo health check should fail if cannot connect") {
+      val client = MongoClients.create("mongodb://localhost:11111")
+      MongoConnectionHealthCheck(client).check().message.shouldBe("Could not connect to mongo instance")
+   }
 
+   test("mongo coroutine health check should connect to mongo") {
+      val client = MongoClient.create(container.connectionString)
+      MongoConnectionHealthCheck(
+         client,
+      ).check() shouldBe HealthCheckResult.healthy("Connected to mongo instance (3 databases)")
+   }
+
+   test("mongo coroutine check should fail if cannot connect") {
+      val client = MongoClient.create("mongodb://localhost:11111")
+      MongoConnectionHealthCheck(client).check().message.shouldBe("Could not connect to mongo instance")
+   }
 })

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -67,8 +67,9 @@ dependencyResolutionManagement {
          library("dbcp2", "org.apache.commons:commons-dbcp2:2.11.0")
          library("pulsar-client", "org.apache.pulsar:pulsar-client:2.11.2")
 
-         val mongo = "4.9.1"
+         val mongo = "5.1.0"
          library("mongodb-driver-sync", "org.mongodb:mongodb-driver-sync:$mongo")
+         library("mongodb-driver-coroutine", "org.mongodb:mongodb-driver-kotlin-coroutine:$mongo")
 
          library(
             "elasticsearch-rest-high-level-client",


### PR DESCRIPTION
I wanted to use the existing mongodb healthcheck and realized that the current healthcheck only supports the mongodb sync driver. I'm using the kotlin coroutine driver. So I added support for it to the library.