### PR TITLE
fix(ktor): bump to 3.0.0

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -91,7 +91,7 @@ dependencyResolutionManagement {
          library("log4j2-core", "org.apache.logging.log4j:log4j-core:$log4j2")
          library("log4j2-slf4j2-impl", "org.apache.logging.log4j:log4j-slf4j2-impl:$log4j2")
 
-         val ktor = "2.3.12"
+         val ktor = "3.0.0"
          library("ktor-client-apache5", "io.ktor:ktor-client-apache5:$ktor")
          library("ktor-server-host-common", "io.ktor:ktor-server-host-common:$ktor")
          library("ktor-server-netty", "io.ktor:ktor-server-netty:$ktor")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,8 @@ include(
 enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
+plugins { id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0" }
+
 dependencyResolutionManagement {
    versionCatalogs {
       create("libs") {


### PR DESCRIPTION
Using current version of cohort with Ktor 3.0.0 causes the following exception:
```
Exception in thread "main" java.lang.NoClassDefFoundError: io/ktor/server/routing/RoutingKt
	at com.sksamuel.cohort.PluginKt$Cohort$2.invoke(plugin.kt:14)
	at com.sksamuel.cohort.PluginKt$Cohort$2.invoke(plugin.kt:11)
	at io.ktor.server.application.CreatePluginUtilsKt.setupPlugin(CreatePluginUtils.kt:276)
	at io.ktor.server.application.CreatePluginUtilsKt.createPluginInstance(CreatePluginUtils.kt:245)
	at io.ktor.server.application.CreatePluginUtilsKt.access$createPluginInstance(CreatePluginUtils.kt:1)
	at io.ktor.server.application.ApplicationPluginImpl.install(CreatePluginUtils.kt:83)
	at io.ktor.server.application.ApplicationPluginImpl.install(CreatePluginUtils.kt:71)
	at io.ktor.server.application.ApplicationPluginKt.install(ApplicationPlugin.kt:100)

```

since `routing` method is now located in `RoutingRoot.kt` instead if `Routing.kt`. Compiling cohort against Ktor 3.0.0 will fix that.

I've also added foojay plugin to resolve Java toolchains automatically with Gradle.