### PR TITLE
feat: use real free memory

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/FreememHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/FreememHealthCheck.kt
@@ -20,9 +20,10 @@ class FreememHealthCheck(private val minFreeBytes: Int) : HealthCheck {
   override val name: String = "free_mem"
 
   override suspend fun check(): HealthCheckResult {
-    val free = Runtime.getRuntime().freeMemory()
-    val msg = "Freemem $free bytes [min free $minFreeBytes]"
-    return if (free < minFreeBytes) {
+    val usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()
+    val freeMemory = Runtime.getRuntime().maxMemory() - usedMemory
+    val msg = "Freemem $freeMemory bytes [min free $minFreeBytes]"
+    return if (freeMemory < minFreeBytes) {
       HealthCheckResult.unhealthy(msg, null)
     } else {
       HealthCheckResult.healthy(msg)


### PR DESCRIPTION
We were getting many warnings about the memory usage in our application but based on the observation this was false alarm. We find out that 
`Runtime.getRuntime().freeMemory();` - shows the free memory within the currently allocated heap space of the JVM

![image](https://github.com/user-attachments/assets/e3823922-073a-4dba-8ff7-c7ac19dea921)


**Current Allocated Free Memory**: The value returned by Runtime.getRuntime().freeMemory() represents the amount of memory that is currently allocated by the JVM and is available for new objects. This is the memory that the JVM has already reserved from the operating system and is ready to use for new object allocations.

**Not Total Free Available Memory**: The value does not represent the total free memory available to the JVM from the operating system. The JVM can potentially request more memory from the operating system if needed, up to the maximum memory limit specified (e.g., using the -Xmx JVM option).

```
Runtime.getRuntime().freeMemory(): 48959784 / 46.691688537597656 MB - cohort is using this right now 
Runtime.getRuntime().maxMemory() - Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() 1561652952 / 1489.3083114624023 MB - new approach

# K8s resources with -XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0
resources:
  requests:
    cpu: "1"
    memory: "1536Mi"
  limits:
    cpu: "2"
    memory: "2Gi"

```


source:
- https://stackoverflow.com/a/18375641