### PR TITLE
Remove runBlocking from HealthCheck registry and leverage the supplied dispatcher for coordinating the launch scope.

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
@@ -2,10 +2,7 @@
 
 package com.sksamuel.cohort
 
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.*
 import org.slf4j.LoggerFactory
 import java.time.Instant
 import java.util.concurrent.ConcurrentHashMap
@@ -22,21 +19,19 @@ import kotlin.time.Duration.Companion.seconds
  * Individual checks are free to shift the dispatcher onto a [Dispatchers.IO] for IO calls.
  * It is recommended that the provided dispatcher has parallelism limited to 1.
  *
- * This registry creates one additional thread for its own use, to run the scheduler. This thread remains
- * in [Thread.State.BLOCKED] while waiting to fire a scheduled event, and this thread is not used
- * for the actual execution of the scheduled events.
- *
  * @param dispatcher this dispatcher will be used for executing the checks
  */
 class HealthCheckRegistry(
    private val dispatcher: CoroutineDispatcher,
 ) : AutoCloseable {
 
+   private val scope = CoroutineScope(dispatcher)
    private val scheduler = Executors.newScheduledThreadPool(1, NamedThreadFactory("cohort-healthcheck-scheduler"))
    private val names = mutableSetOf<String>()
 
    private val checks = ConcurrentHashMap<String, HealthCheck>()
    private val statuses = ConcurrentHashMap<String, HealthCheckStatus>()
+   private val jobs = ConcurrentHashMap<String, Job>()
 
    private val logger = LoggerFactory.getLogger(HealthCheckRegistry::class.java)
    private val subscribers = ConcurrentHashMap.newKeySet<Subscriber>()
@@ -167,11 +162,14 @@ class HealthCheckRegistry(
 
       scheduler.scheduleWithFixedDelay(
          {
-            // we block the thread used by the scheduler, as we execute inside the provided coroutine dispatcher
-            runBlocking {
-               launch(dispatcher) {
+            val previousCheck = jobs[name]
+            if(previousCheck == null || !previousCheck.isActive) {
+               jobs[name] = scope.launch(dispatcher) {
                   run(name)
+                  jobs.remove(name)
                }
+            } else {
+               logger.debug("Check $name is still running. Skipping rescheduling to avoid pileup")
             }
          },
          initialDelay.inWholeMilliseconds,
@@ -270,6 +268,7 @@ class HealthCheckRegistry(
    }
 
    override fun close() {
+      scope.cancel()
       scheduler.shutdown()
    }
 }

--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
@@ -164,7 +164,7 @@ class HealthCheckRegistry(
          {
             val previousCheck = jobs[name]
             if(previousCheck == null || !previousCheck.isActive) {
-               jobs[name] = scope.launch(dispatcher) {
+               jobs[name] = scope.launch {
                   run(name)
                   jobs.remove(name)
                }

--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/HealthCheckRegistryTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/HealthCheckRegistryTest.kt
@@ -1,8 +1,19 @@
 package com.sksamuel.cohort
 
+import com.sksamuel.cohort.HealthCheckRegistry.Companion.DEFAULT_INTERVAL
 import com.sksamuel.cohort.threads.ThreadDeadlockHealthCheck
 import io.kotest.assertions.throwables.shouldThrowAny
+import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.comparables.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.delay
+import org.testcontainers.shaded.org.bouncycastle.oer.its.ieee1609dot2.basetypes.Duration
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Duration.Companion.milliseconds
 
 class HealthCheckRegistryTest : FunSpec({
 
@@ -13,6 +24,57 @@ class HealthCheckRegistryTest : FunSpec({
             register(ThreadDeadlockHealthCheck())
          }
       }
+   }
+
+   class SlowHealthCheck(val id: String, val blocker: AtomicBoolean = AtomicBoolean(true),
+                         val callCount: AtomicLong = AtomicLong(0),
+
+   ) : HealthCheck {
+      override suspend fun check(): HealthCheckResult {
+         callCount.incrementAndGet()
+         while(blocker.get()) {
+            Thread.sleep(1)
+         }
+         return HealthCheckResult.healthy("Slow")
+      }
+   }
+
+
+   test("slow blocking check should not hold up existing checks") {
+       val check1 = SlowHealthCheck("1").apply { blocker.set(false) }
+       val check2 = SlowHealthCheck("2")
+       val check3 = SlowHealthCheck("3").apply { blocker.set(false) }
+
+      val reg = HealthCheckRegistry {
+         register("check1", check1, 1.milliseconds, 1.milliseconds)
+         register("check2", check2, 1.milliseconds,  1.milliseconds)
+         register("check3", check3,  1.milliseconds,  1.milliseconds)
+      }
+
+      delay(5)
+
+      reg.status().apply {
+         this.healthy shouldBe false
+         this.healthchecks.size shouldBe 3
+
+         this.healthchecks["check2"]?.result?.isHealthy shouldBe false
+         withClue("Check 2 should still be waiting for first run to finish") { check2.callCount.get() shouldBe 1 }
+         this.healthchecks["check3"]?.result?.isHealthy shouldBe true
+      }
+
+      //Unblock the slow 2nd check
+      check2.blocker.set(false)
+
+      delay(3)
+
+      reg.status().apply {
+         this.healthy shouldBe true
+         this.healthchecks.size shouldBe 3
+
+         this.healthchecks.all { it.value.result.isHealthy shouldBe true }
+         check2.callCount.get() shouldBeGreaterThan 1
+      }
+
    }
 
 })


### PR DESCRIPTION
I included some test to show how the slow checks wold not affect the other checks. However since they include hard-coded delays, I'm happy to remove them, though I kept them very small.