### PR TITLE
Added CassandraDriverHealthCheck

### DIFF
--- a/cohort-cassandra/build.gradle.kts
+++ b/cohort-cassandra/build.gradle.kts
@@ -1,0 +1,9 @@
+dependencies {
+   implementation(projects.cohortApi)
+   api(libs.cassandra)
+   testImplementation(libs.testcontainers.cassandra)
+   testImplementation(libs.slf4j.simple)
+   testImplementation(libs.mockk)
+}
+
+apply("../publish.gradle.kts")

--- a/cohort-cassandra/src/main/kotlin/com/sksamuel/cohort/cassandra/CassandraDriverHealthCheck.kt
+++ b/cohort-cassandra/src/main/kotlin/com/sksamuel/cohort/cassandra/CassandraDriverHealthCheck.kt
@@ -1,0 +1,25 @@
+package com.sksamuel.cohort.cassandra
+
+import com.sksamuel.cohort.HealthCheck
+import com.sksamuel.cohort.HealthCheckResult
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.metadata.NodeState
+
+class CassandraDriverHealthCheck(
+   private val session: CqlSession,
+   override val name: String = "cassandra",
+) : HealthCheck {
+
+   override suspend fun check(): HealthCheckResult =
+      runCatching {
+         session.metadata.nodes.values.any { node -> node.state == NodeState.UP }
+      }.fold(
+         onSuccess = { anyUp ->
+            if (anyUp) HealthCheckResult.healthy("Cassandra access successful")
+            else HealthCheckResult.unhealthy("Could not access to Cassandra")
+         },
+         onFailure = { error ->
+            HealthCheckResult.unhealthy("Could not access to Cassandra", error)
+         }
+      )
+}

--- a/cohort-cassandra/src/test/kotlin/com/sksaumel/cohort/cassandra/CassandraDriverHealthCheckContainerTest.kt
+++ b/cohort-cassandra/src/test/kotlin/com/sksaumel/cohort/cassandra/CassandraDriverHealthCheckContainerTest.kt
@@ -1,0 +1,70 @@
+package com.sksaumel.cohort.cassandra
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.sksamuel.cohort.HealthCheck
+import com.sksamuel.cohort.HealthStatus
+import com.sksamuel.cohort.cassandra.CassandraDriverHealthCheck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.testcontainers.containers.CassandraContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.utility.DockerImageName
+import java.net.InetSocketAddress
+
+class CassandraDriverHealthCheckContainerTest : FunSpec({
+
+   val network = Network.newNetwork()
+   val cassandra = CassandraContainer(DockerImageName.parse("cassandra:5.0")).apply {
+      withNetwork(network)
+      withNetworkAliases("cassandra")
+      withEnv("CASSANDRA_CLUSTER_NAME", "cluster")
+      withEnv("CASSANDRA_ENDPOINT_SNITCH", "GossipingPropertyFileSnitch")
+      withEnv("CASSANDRA_KEYSPACE", "keyspace")
+      withEnv("CASSANDRA_DC", "dc1")
+      withEnv("CASSANDRA_RACK", "rack1")
+      withExposedPorts(9042)
+   }
+
+   beforeSpec {
+      cassandra.start()
+   }
+
+   afterSpec {
+      cassandra.close()
+   }
+
+   test("healthy when a node is running") {
+      val session = CqlSession.builder()
+         .addContactPoint(InetSocketAddress(cassandra.host, cassandra.getMappedPort(9042)))
+         .withLocalDatacenter("dc1")
+         .build()
+
+      val healthCheck: HealthCheck = CassandraDriverHealthCheck(session)
+      healthCheck.check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("unhealthy when a node is down") {
+      val session = CqlSession.builder()
+         .addContactPoint(InetSocketAddress(cassandra.host, cassandra.getMappedPort(9042)))
+         .withLocalDatacenter("dc1")
+         .build()
+      val healthCheck: HealthCheck = CassandraDriverHealthCheck(session)
+      // healthy before applying toxic
+      healthCheck.check().status shouldBe HealthStatus.Healthy
+
+      // run disablebinary
+      cassandra.execInContainer("nodetool", "disablebinary")
+
+      // refresh session
+      val unhealthyExpected = runCatching {
+         CqlSession.builder()
+            .addContactPoint(InetSocketAddress(cassandra.host, cassandra.getMappedPort(9042)))
+            .withLocalDatacenter("dc1")
+            .build()
+            .use {
+               CassandraDriverHealthCheck(it).check().status
+            }
+      }.getOrDefault(HealthStatus.Unhealthy) // AllNodesFailedException
+      unhealthyExpected shouldBe HealthStatus.Unhealthy
+   }
+})

--- a/cohort-cassandra/src/test/kotlin/com/sksaumel/cohort/cassandra/CassandraDriverHealthCheckMockTest.kt
+++ b/cohort-cassandra/src/test/kotlin/com/sksaumel/cohort/cassandra/CassandraDriverHealthCheckMockTest.kt
@@ -1,0 +1,60 @@
+package com.sksaumel.cohort.cassandra
+
+import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.metadata.Metadata
+import com.datastax.oss.driver.api.core.metadata.Node
+import com.datastax.oss.driver.api.core.metadata.NodeState
+import com.sksamuel.cohort.HealthStatus
+import com.sksamuel.cohort.cassandra.CassandraDriverHealthCheck
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import java.util.UUID
+
+class CassandraDriverHealthCheckTest : FunSpec({
+
+   test("healthy when one node is running") {
+      val session = mockk<CqlSession>()
+      val metadata = mockk<Metadata>()
+      val healthyNode = mockk<Node>()
+      every { session.metadata } returns metadata
+      every { metadata.nodes } returns mapOf(UUID.randomUUID() to healthyNode)
+      every { healthyNode.state } returns NodeState.UP
+
+      val check = CassandraDriverHealthCheck(session)
+      check.check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("healthy when at least one node is running") {
+      val session = mockCqlSessionWithNodeState(
+         NodeState.UP, NodeState.UNKNOWN, NodeState.DOWN, NodeState.FORCED_DOWN
+      )
+      val check = CassandraDriverHealthCheck(session)
+      check.check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("unhealthy when all nodes are down") {
+      val session = mockCqlSessionWithNodeState(NodeState.DOWN, NodeState.FORCED_DOWN)
+      val check = CassandraDriverHealthCheck(session)
+      check.check().status shouldBe HealthStatus.Unhealthy
+   }
+})
+
+fun mockCqlSessionWithNodeState(vararg states: NodeState): CqlSession {
+   val session = mockk<CqlSession>()
+   val metadata = mockk<Metadata>()
+   val nodes = states.map { state ->
+      mockk<Node> {
+         every { this@mockk.state } returns state
+      }
+   }
+
+   every { session.metadata } returns metadata
+   every { metadata.nodes } returns createNodesWithRandomUUID(nodes)
+
+   return session
+}
+
+fun createNodesWithRandomUUID(nodes: List<Node>): Map<UUID, Node> =
+   nodes.associateBy { UUID.randomUUID() }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,7 @@ include(
    "cohort-aws-s3",
    "cohort-aws-sqs",
    "cohort-aws-sns",
+   "cohort-cassandra",
    "cohort-dbcp",
    "cohort-elastic",
    "cohort-flyway",
@@ -130,6 +131,7 @@ dependencyResolutionManagement {
          library("testcontainers-elasticsearch", "org.testcontainers:elasticsearch:$testContainers")
          library("testcontainers-mongodb", "org.testcontainers:mongodb:$testContainers")
          library("testcontainers-kafka", "org.testcontainers:kafka:$testContainers")
+         library("testcontainers-cassandra", "org.testcontainers:cassandra:$testContainers")
 
          val vertx = "4.5.9"
          library("vertx-core", "io.vertx:vertx-core:$vertx")
@@ -137,6 +139,12 @@ dependencyResolutionManagement {
          library("vertx-kotlin", "io.vertx:vertx-lang-kotlin:$vertx")
          library("vertx-coroutines", "io.vertx:vertx-lang-kotlin-coroutines:$vertx")
          library("vertx-micrometer", "io.vertx:vertx-micrometer-metrics:$vertx")
+
+         val cassandra = "4.19.0"
+         library("cassandra", "org.apache.cassandra:java-driver-core:$cassandra")
+
+         val mockk = "1.14.2"
+         library("mockk", "io.mockk:mockk:$mockk")
 
          bundle(
             "testing", listOf(


### PR DESCRIPTION
Summary:
Add a new health‐check implementation for Cassandra to the cohort library, including tests.

Motivation:
Currently cohort provides health checks for a variety of services(e.g. Kafka, Elasticsearch), but there is no support for Cassandra.