### PR TITLE
Fix: Liquibase RanChangeSet tracking & Jackson date serialization

### DIFF
--- a/cohort-ktor/build.gradle.kts
+++ b/cohort-ktor/build.gradle.kts
@@ -1,6 +1,7 @@
 dependencies {
    api(projects.cohortApi)
    implementation(libs.jackson.module.kotlin)
+   implementation(libs.jackson.datatype.jsr310)
    implementation(libs.ktor.server.host.common)
    implementation(libs.ktor.client.apache5)
    testImplementation(libs.ktor.server.netty)

--- a/cohort-ktor/src/main/kotlin/com/sksamuel/cohort/endpoints/json.kt
+++ b/cohort-ktor/src/main/kotlin/com/sksamuel/cohort/endpoints/json.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.cohort.endpoints
 
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.sksamuel.cohort.HealthStatus
 import com.sksamuel.cohort.db.DataSourceInfo
@@ -37,4 +39,5 @@ fun SysProps.toJson(): String = mapper.writeValueAsString(this)
 fun GCInfo.toJson(): String = mapper.writeValueAsString(this)
 fun MemoryInfo.toJson(): String = mapper.writeValueAsString(this)
 
-val mapper = jacksonObjectMapper()
+val mapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+   .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/cohort-liquibase/src/main/kotlin/com/sksamuel/cohort/liquibase/LiquibaseMigrations.kt
+++ b/cohort-liquibase/src/main/kotlin/com/sksamuel/cohort/liquibase/LiquibaseMigrations.kt
@@ -3,37 +3,55 @@ package com.sksamuel.cohort.liquibase
 import com.sksamuel.cohort.db.DatabaseMigrationManager
 import com.sksamuel.cohort.db.Migration
 import liquibase.Liquibase
+import liquibase.changelog.StandardChangeLogHistoryService
+import liquibase.database.DatabaseFactory
 import liquibase.database.jvm.JdbcConnection
 import liquibase.resource.ClassLoaderResourceAccessor
 import java.time.Instant
 import javax.sql.DataSource
 
 class LiquibaseMigrations(
-  private val ds: DataSource,
-  private val changelogFile: String,
+   private val ds: DataSource,
+   private val changelogFile: String,
 ) : DatabaseMigrationManager {
 
-  override fun migrations(): Result<List<Migration>> = runCatching {
-    ds.connection.use { conn ->
+   override fun migrations(): Result<List<Migration>> = runCatching {
+      ds.connection.use { conn ->
+         val database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(JdbcConnection(conn))
+         val liquibase = Liquibase(
+            changelogFile,
+            ClassLoaderResourceAccessor(),
+            database
+         )
 
-      val l = Liquibase(
-        changelogFile,
-        ClassLoaderResourceAccessor(),
-        JdbcConnection(conn)
-      )
+         val service = StandardChangeLogHistoryService()
+         service.database = database
+         val appliedChangeSets = service.getRanChangeSets()
+         val appliedIds = appliedChangeSets.map { "${it.id}:${it.author}" }.toSet()
 
-      l.databaseChangeLog.changeSets.map { changeset ->
-        Migration(
-          script = changeset.filePath,
-          description = changeset.description,
-          checksum = changeset.storedCheckSum.toString(),
-          author = changeset.author,
-          timestamp = Instant.ofEpochMilli(0),
-          version = "",
-          state = "unknown",
-        )
+         liquibase.databaseChangeLog.changeSets.map { changeset ->
+            val changesetId = "${changeset.id}:${changeset.author}"
+            val isApplied = appliedIds.contains(changesetId)
+
+            val appliedChangeSet = if (isApplied) {
+               appliedChangeSets.find { it.id == changeset.id && it.author == changeset.author }
+            } else null
+
+            Migration(
+               script = changeset.filePath,
+               description = changeset.description ?: "",
+               checksum = changeset.storedCheckSum?.toString() ?: "",
+               author = changeset.author,
+               timestamp = appliedChangeSet?.let { Instant.ofEpochMilli(it.dateExecuted.time) } ?: Instant.ofEpochMilli(
+                  0
+               ),
+               version = "",
+               state = if (isApplied) "applied" else "pending"
+            )
+
+         }
       }
 
-    }
-  }
+   }
 }
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -104,6 +104,7 @@ dependencyResolutionManagement {
 
          val jackson = "2.17.2"
          library("jackson-core", "com.fasterxml.jackson.core:jackson-core:$jackson")
+         library("jackson-datatype-jsr310","com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson")
          library("jackson-module-kotlin", "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson")
 
          val kotest = "5.9.1"


### PR DESCRIPTION
## Liquibase Update
Fixed issue where Liquibase wasn't correctly retrieving RanChangeSets, which caused errors in the migration status endpoint.

- Problem can be reproduced in the test app: `git clone -b cohort_feature_for_healthchecks git@github.com:ozgurdemirel/Ktor-Task-List-App.git`
- `make run` and Check endpoint http://0.0.0.0:8080/admin/dbmigration to see the error
- **Technical context**: Properly differentiated between Changesets (planned changes) and RanChangesets (applied changes)

## For Ktor - Jackson Date/Time Serialization
Fixed serialization of Java 8 date/time types (specifically java.time.Instant) in Migration data class.

- Added jackson-datatype-jsr310 dependency
- .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) configures dates to be written as ISO-8601 strings (like "2023-06-15T14:30:00Z") instead of numeric timestamps
