### PR TITLE
Upgrade Jackson to remediate vulnerability GHSA-72hv-8253-57qq

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -95,7 +95,7 @@ dependencyResolutionManagement {
          library("logback-classic", "ch.qos.logback:logback-classic:$logback")
          library("logback-core", "ch.qos.logback:logback-core:$logback")
 
-         val jackson = "2.19.0"
+         val jackson = "2.21.1"
          library("jackson-core", "com.fasterxml.jackson.core:jackson-core:$jackson")
          library("jackson-datatype-jsr310","com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jackson")
          library("jackson-module-kotlin", "com.fasterxml.jackson.module:jackson-module-kotlin:$jackson")


### PR DESCRIPTION
jackson-core 2.19.0 has a high severity vulnerability [GHSA-72hv-8253-57qq](https://github.com/advisories/GHSA-72hv-8253-57qq). The vulnerability has been patched in 2.21.1.

Although the vulnerability is most likely not exploitable in Cohort, it is setting off the alarm in some vulnerability analysis tools.