### PR TITLE
Upgrade Ktor to 3.4.2 and Kotlin to 2.3.0

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,6 +9,6 @@ plugins {
 }
 
 dependencies {
-   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.21")
+   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.0")
    implementation("com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin:0.34.0")
 }

--- a/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -38,8 +38,8 @@ kotlin {
    jvmToolchain(11)
    compilerOptions {
       jvmTarget.set(JvmTarget.JVM_11)
-      apiVersion.set(KotlinVersion.KOTLIN_2_1)
-      languageVersion.set(KotlinVersion.KOTLIN_2_1)
+      apiVersion.set(KotlinVersion.KOTLIN_2_3)
+      languageVersion.set(KotlinVersion.KOTLIN_2_3)
    }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -85,7 +85,7 @@ dependencyResolutionManagement {
          library("log4j2-core", "org.apache.logging.log4j:log4j-core:$log4j2")
          library("log4j2-slf4j2-impl", "org.apache.logging.log4j:log4j-slf4j2-impl:$log4j2")
 
-         val ktor = "3.2.3"
+         val ktor = "3.4.2"
          library("ktor-client-apache5", "io.ktor:ktor-client-apache5:$ktor")
          library("ktor-server-host-common", "io.ktor:ktor-server-host-common:$ktor")
          library("ktor-server-netty", "io.ktor:ktor-server-netty:$ktor")


### PR DESCRIPTION
## Summary

- Bumps Ktor from 3.2.3 → 3.4.2
- Bumps Kotlin Gradle plugin from 2.1.21 → 2.3.0 (required by Ktor 3.4.2)
- Updates language/API version targets from `KOTLIN_2_1` → `KOTLIN_2_3`

## Test plan

- [x] `./gradlew :cohort-ktor:build` passes with all tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)