### PR TITLE
Fix resource leaks and logic bugs in health checks

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/network/TcpHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/network/TcpHealthCheck.kt
@@ -19,17 +19,17 @@ class TcpHealthCheck(
 
    override suspend fun check(): HealthCheckResult {
       return runCatching {
-         val socket = Socket()
-         val start = System.currentTimeMillis()
-         socket.connect(InetSocketAddress(host, port), connectionTimeout.inWholeMilliseconds.toInt())
-         val time = (System.currentTimeMillis() - start).milliseconds
-         if (socket.isConnected) {
-            withContext(Dispatchers.IO) {
-               socket.close()
+         withContext(Dispatchers.IO) {
+            Socket().use { socket ->
+               val start = System.currentTimeMillis()
+               socket.connect(InetSocketAddress(host, port), connectionTimeout.inWholeMilliseconds.toInt())
+               val time = (System.currentTimeMillis() - start).milliseconds
+               if (socket.isConnected) {
+                  HealthCheckResult.healthy("Connected to $host:$port after ${time.inWholeMilliseconds}ms")
+               } else {
+                  HealthCheckResult.unhealthy("Connection to $host:$port timed out after $connectionTimeout", null)
+               }
             }
-            HealthCheckResult.healthy("Connected to $host:$port after ${time.inWholeMilliseconds}ms")
-         } else {
-            HealthCheckResult.unhealthy("Connection to $host:$port timed out after $connectionTimeout", null)
          }
       }.getOrElse { HealthCheckResult.unhealthy("Connection to $host:$port failed", it) }
    }

--- a/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaConsumerRecordsConsumedHealthCheck.kt
+++ b/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaConsumerRecordsConsumedHealthCheck.kt
@@ -26,16 +26,17 @@ class KafkaConsumerRecordsConsumedHealthCheck(
    }
 
    private val metricName = "records-consumed-total"
-   private var lastTotal = 0L
+   @Volatile private var lastTotal = 0L
 
    override suspend fun check(): HealthCheckResult {
       return metric(metricName).map { metric ->
          val total = metric.metricValue().toString().toDoubleOrNull()?.roundToLong() ?: 0L
-         val diff = lastTotal - total
+         val diff = total - lastTotal
+         lastTotal = total
          val msg = "Kafka consumer $metricName total=$total diff=$diff [minRecords $minRecords]"
          return when {
             total == 0L -> HealthCheckResult.healthy(msg)
-            total < minRecords -> HealthCheckResult.unhealthy(msg, null)
+            diff < minRecords -> HealthCheckResult.unhealthy(msg, null)
             else -> HealthCheckResult.healthy(msg)
          }
       }.fold({ it }, { it })

--- a/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaProducerCountHealthCheck.kt
+++ b/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaProducerCountHealthCheck.kt
@@ -19,7 +19,7 @@ class KafkaProducerCountHealthCheck(
 
    private val metricName = "record-send-total"
 
-   private var lastTotal: Long = -1
+   @Volatile private var lastTotal: Long = -1
 
    override suspend fun check(): HealthCheckResult {
 

--- a/cohort-rabbit/src/main/kotlin/com/sksamuel/cohort/rabbit/RabbitConnectionHealthCheck.kt
+++ b/cohort-rabbit/src/main/kotlin/com/sksamuel/cohort/rabbit/RabbitConnectionHealthCheck.kt
@@ -17,8 +17,9 @@ class RabbitConnectionHealthCheck(
       return runCatching {
          withTimeout(5.seconds) {
             runInterruptible(Dispatchers.IO) {
-               factory.newConnection()
-               HealthCheckResult.healthy("Connected to rabbit instance")
+               factory.newConnection().use {
+                  HealthCheckResult.healthy("Connected to rabbit instance")
+               }
             }
          }
       }.getOrElse {

--- a/cohort-rabbit/src/main/kotlin/com/sksamuel/cohort/rabbit/RabbitQueueHealthCheck.kt
+++ b/cohort-rabbit/src/main/kotlin/com/sksamuel/cohort/rabbit/RabbitQueueHealthCheck.kt
@@ -24,10 +24,12 @@ class RabbitQueueHealthCheck(
       return runCatching {
          withTimeout(5.seconds) {
             runInterruptible(Dispatchers.IO) {
-               val conn = factory.newConnection()
-               val channel = conn.createChannel()
-               channel.queueDeclarePassive(queue)
-               HealthCheckResult.healthy("Confirmed connection to RabbitMQ queue $queue")
+               factory.newConnection().use { conn ->
+                  conn.createChannel().use { channel ->
+                     channel.queueDeclarePassive(queue)
+                     HealthCheckResult.healthy("Confirmed connection to RabbitMQ queue $queue")
+                  }
+               }
             }
          }
       }.getOrElse {


### PR DESCRIPTION
## Summary

- **TcpHealthCheck**: socket was only closed on the happy path. Now uses `Socket().use {}` wrapping the connect+check, and the blocking connect is moved to `Dispatchers.IO`.
- **RabbitConnectionHealthCheck**: `factory.newConnection()` was called to verify connectivity but the returned connection was never closed. Now uses `.use {}`.
- **RabbitQueueHealthCheck**: same leak — connection and channel created but never closed. Now both wrapped with `.use {}`.
- **KafkaConsumerRecordsConsumedHealthCheck** (three bugs):
  - `diff` was `lastTotal - total` (inverted) — fixed to `total - lastTotal`
  - `lastTotal` was never updated, so diff was always wrong — `lastTotal = total` added after computing diff
  - Condition compared `total < minRecords` instead of `diff < minRecords`, contradicting the stated intent ("minimum records *between invocations*")
  - Added `@Volatile` on `lastTotal`
- **KafkaProducerCountHealthCheck**: added `@Volatile` on `lastTotal` for safe access across coroutine dispatchers

## Test plan

- [x] `./gradlew :cohort-api:build :cohort-rabbit:build :cohort-kafka:build :cohort-ktor:build` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)