### PR TITLE
Fix connection leak in RabbitConnectionHealthCheck

### DIFF
--- a/cohort-rabbit/src/main/kotlin/com/sksamuel/cohort/rabbit/RabbitConnectionHealthCheck.kt
+++ b/cohort-rabbit/src/main/kotlin/com/sksamuel/cohort/rabbit/RabbitConnectionHealthCheck.kt
@@ -17,8 +17,9 @@ class RabbitConnectionHealthCheck(
       return runCatching {
          withTimeout(5.seconds) {
             runInterruptible(Dispatchers.IO) {
-               factory.newConnection()
-               HealthCheckResult.healthy("Connected to rabbit instance")
+               factory.newConnection().use {
+                  HealthCheckResult.healthy("Connected to rabbit instance")
+               }
             }
          }
       }.getOrElse {

--- a/cohort-rabbit/src/test/kotlin/com/sksamuel/cohort/mongo/RabbitConnectionHealthCheckTest.kt
+++ b/cohort-rabbit/src/test/kotlin/com/sksamuel/cohort/mongo/RabbitConnectionHealthCheckTest.kt
@@ -1,5 +1,6 @@
 package com.sksamuel.cohort.mongo
 
+import com.rabbitmq.client.Connection
 import com.rabbitmq.client.ConnectionFactory
 import com.sksamuel.cohort.HealthCheckResult
 import com.sksamuel.cohort.rabbit.RabbitConnectionHealthCheck
@@ -32,4 +33,21 @@ class RabbitConnectionHealthCheckTest : FunSpec({
       .message.shouldBe("Could not connect to rabbit instance")
   }
 
+  test("connection is closed after a successful check") {
+    val createdConnections = mutableListOf<Connection>()
+
+    val trackingFactory = object : ConnectionFactory() {
+      override fun newConnection(): Connection {
+        return super.newConnection().also { createdConnections += it }
+      }
+    }.apply {
+      host = container.host
+      port = container.amqpPort
+    }
+
+    RabbitConnectionHealthCheck(trackingFactory).check()
+
+    createdConnections.size shouldBe 1
+    createdConnections[0].isOpen shouldBe false
+  }
 })


### PR DESCRIPTION
## Summary

`factory.newConnection()` was called to verify connectivity but the returned `Connection` was never closed, leaking one AMQP connection per health check invocation. Wrap the result in `.use {}` so it is always closed.

## Tests added

New test case in `RabbitConnectionHealthCheckTest`: subclasses `ConnectionFactory` to capture the created connection and asserts `isOpen == false` after the check completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)