### PR TITLE
Fix connection and channel leak in RabbitQueueHealthCheck

### DIFF
--- a/cohort-rabbit/src/main/kotlin/com/sksamuel/cohort/rabbit/RabbitQueueHealthCheck.kt
+++ b/cohort-rabbit/src/main/kotlin/com/sksamuel/cohort/rabbit/RabbitQueueHealthCheck.kt
@@ -24,10 +24,12 @@ class RabbitQueueHealthCheck(
       return runCatching {
          withTimeout(5.seconds) {
             runInterruptible(Dispatchers.IO) {
-               val conn = factory.newConnection()
-               val channel = conn.createChannel()
-               channel.queueDeclarePassive(queue)
-               HealthCheckResult.healthy("Confirmed connection to RabbitMQ queue $queue")
+               factory.newConnection().use { conn ->
+                  conn.createChannel().use { channel ->
+                     channel.queueDeclarePassive(queue)
+                     HealthCheckResult.healthy("Confirmed connection to RabbitMQ queue $queue")
+                  }
+               }
             }
          }
       }.getOrElse {

--- a/cohort-rabbit/src/test/kotlin/com/sksamuel/cohort/rabbit/RabbitQueueHealthCheckTest.kt
+++ b/cohort-rabbit/src/test/kotlin/com/sksamuel/cohort/rabbit/RabbitQueueHealthCheckTest.kt
@@ -1,0 +1,71 @@
+package com.sksamuel.cohort.rabbit
+
+import com.rabbitmq.client.Channel
+import com.rabbitmq.client.Connection
+import com.rabbitmq.client.ConnectionFactory
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.extensions.install
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.testcontainers.TestContainerSpecExtension
+import io.kotest.matchers.shouldBe
+import org.testcontainers.containers.RabbitMQContainer
+import org.testcontainers.utility.DockerImageName
+
+class RabbitQueueHealthCheckTest : FunSpec({
+
+   val container = RabbitMQContainer(DockerImageName.parse("rabbitmq"))
+   install(TestContainerSpecExtension(container))
+
+   fun factory() = ConnectionFactory().apply {
+      host = container.host
+      port = container.amqpPort
+   }
+
+   beforeSpec {
+      // Create the queue used in the healthy tests
+      factory().newConnection().use { conn ->
+         conn.createChannel().use { ch ->
+            ch.queueDeclare("test-queue", false, false, false, null)
+         }
+      }
+   }
+
+   test("returns healthy when queue exists") {
+      RabbitQueueHealthCheck(factory(), "test-queue").check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when queue does not exist") {
+      RabbitQueueHealthCheck(factory(), "no-such-queue").check().status shouldBe HealthStatus.Unhealthy
+   }
+
+   test("connection and channel are closed after a successful check") {
+      val createdConnections = mutableListOf<Connection>()
+      val createdChannels = mutableListOf<Channel>()
+
+      val trackingFactory = object : ConnectionFactory() {
+         override fun newConnection(): Connection {
+            val conn = object : TrackingConnection(super.newConnection()) {
+               override fun createChannel(): Channel {
+                  return super.createChannel().also { createdChannels += it }
+               }
+            }
+            createdConnections += conn
+            return conn
+         }
+      }.apply {
+         host = container.host
+         port = container.amqpPort
+      }
+
+      RabbitQueueHealthCheck(trackingFactory, "test-queue").check()
+
+      createdConnections.size shouldBe 1
+      createdChannels.size shouldBe 1
+      createdConnections[0].isOpen shouldBe false
+      createdChannels[0].isOpen shouldBe false
+   }
+})
+
+private open class TrackingConnection(private val delegate: Connection) : Connection by delegate {
+   override fun createChannel(): Channel = delegate.createChannel()
+}


### PR DESCRIPTION
## Summary

The `Connection` and `Channel` opened for the passive queue declaration were never closed, leaking one AMQP connection and one channel per health check invocation. Wrap both in `.use {}` blocks so they are always closed, even if `queueDeclarePassive` throws.

## Tests added

New `RabbitQueueHealthCheckTest`:
- Returns healthy when the queue exists
- Returns unhealthy when the queue does not exist
- Verifies both the connection and channel are closed after a successful check (using delegation wrappers to track `isOpen`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)