### PR TITLE
Fix three logic bugs in KafkaConsumerRecordsConsumedHealthCheck

### DIFF
--- a/cohort-kafka/build.gradle.kts
+++ b/cohort-kafka/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
 dependencies {
    implementation(projects.cohortApi)
    implementation(libs.kafka.client)
+   testImplementation(libs.mockk)
 }

--- a/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaConsumerRecordsConsumedHealthCheck.kt
+++ b/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaConsumerRecordsConsumedHealthCheck.kt
@@ -26,16 +26,17 @@ class KafkaConsumerRecordsConsumedHealthCheck(
    }
 
    private val metricName = "records-consumed-total"
-   private var lastTotal = 0L
+   @Volatile private var lastTotal = 0L
 
    override suspend fun check(): HealthCheckResult {
       return metric(metricName).map { metric ->
          val total = metric.metricValue().toString().toDoubleOrNull()?.roundToLong() ?: 0L
-         val diff = lastTotal - total
+         val diff = total - lastTotal
+         lastTotal = total
          val msg = "Kafka consumer $metricName total=$total diff=$diff [minRecords $minRecords]"
          return when {
             total == 0L -> HealthCheckResult.healthy(msg)
-            total < minRecords -> HealthCheckResult.unhealthy(msg, null)
+            diff < minRecords -> HealthCheckResult.unhealthy(msg, null)
             else -> HealthCheckResult.healthy(msg)
          }
       }.fold({ it }, { it })

--- a/cohort-kafka/src/test/kotlin/com/sksamuel/cohort/kafka/KafkaConsumerRecordsConsumedHealthCheckTest.kt
+++ b/cohort-kafka/src/test/kotlin/com/sksamuel/cohort/kafka/KafkaConsumerRecordsConsumedHealthCheckTest.kt
@@ -1,70 +1,55 @@
-//package com.sksamuel.cohort.kafka
-//
-//import com.sksamuel.cohort.HealthStatus
-//import io.kotest.assertions.nondeterministic.continually
-//import io.kotest.assertions.nondeterministic.eventually
-//import io.kotest.assertions.withClue
-//import io.kotest.core.extensions.install
-//import io.kotest.core.spec.style.FunSpec
-//import io.kotest.extensions.testcontainers.kafka.KafkaContainerExtension
-//import io.kotest.extensions.testcontainers.kafka.admin
-//import io.kotest.extensions.testcontainers.kafka.consumer
-//import io.kotest.extensions.testcontainers.kafka.producer
-//import io.kotest.matchers.shouldBe
-//import kotlinx.coroutines.delay
-//import kotlinx.coroutines.isActive
-//import kotlinx.coroutines.launch
-//import org.apache.kafka.clients.admin.NewTopic
-//import org.apache.kafka.clients.producer.ProducerRecord
-//import org.apache.kafka.common.utils.Bytes
-//import org.testcontainers.containers.KafkaContainer
-//import org.testcontainers.utility.DockerImageName
-//import java.time.Duration
-//import kotlin.time.Duration.Companion.milliseconds
-//import kotlin.time.Duration.Companion.seconds
-//
-//class KafkaConsumerRecordsConsumedHealthCheckTest : FunSpec({
-//
-//   val kafka = install(KafkaContainerExtension(KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka"))))
-//
-//   test("health check should pass while consumer has not yet consumed") {
-//
-//      kafka.admin().use { it.createTopics(listOf(NewTopic("mytopic1", 1, 1))).all().get() }
-//      val consumer = kafka.consumer()
-//      val healthcheck = KafkaConsumerRecordsConsumedHealthCheck(consumer, 5)
-//      continually(5.seconds) {
-//         healthcheck.check().status shouldBe HealthStatus.Healthy
-//         delay(100.milliseconds)
-//      }
-//   }
-//
-//   test("health check should pass while rate is above threshold") {
-//
-//      kafka.admin().use { it.createTopics(listOf(NewTopic("mytopic2", 1, 1))).all().get() }
-//
-//      val producer = kafka.producer()
-//      val consumer = kafka.consumer()
-//      consumer.subscribe(listOf("mytopic2"))
-//
-//      val job = launch {
-//         while (isActive) {
-//            delay(10)
-//            producer.send(ProducerRecord("mytopic2", Bytes.wrap(byteArrayOf()), Bytes.wrap(byteArrayOf())))
-//         }
-//      }
-//
-//      val healthcheck = KafkaConsumerRecordsConsumedHealthCheck(consumer, 5)
-//      eventually(5.seconds) {
-//         consumer.poll(Duration.ofMillis(100))
-//         val result = healthcheck.check()
-//         withClue(result) {
-//            result.status shouldBe HealthStatus.Healthy
-//         }
-//         delay(250.milliseconds)
-//      }
-//
-//      job.cancel()
-//      producer.close()
-//      consumer.close()
-//   }
-//})
+package com.sksamuel.cohort.kafka
+
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.common.Metric
+import org.apache.kafka.common.MetricName
+
+class KafkaConsumerRecordsConsumedHealthCheckTest : FunSpec({
+
+   fun consumer(vararg totals: Double): Consumer<*, *> {
+      val consumer = mockk<Consumer<*, *>>()
+      val metricName = MetricName("records-consumed-total", "consumer-fetch-manager-metrics", "", emptyMap())
+      val responses = totals.map { value ->
+         val metric = mockk<Metric>()
+         every { metric.metricName() } returns metricName
+         every { metric.metricValue() } returns value
+         mapOf(metricName to metric)
+      }
+      every { consumer.metrics() } returnsMany responses
+      return consumer
+   }
+
+   test("returns healthy when total is zero (consumer not yet started)") {
+      val check = KafkaConsumerRecordsConsumedHealthCheck(consumer(0.0), minRecords = 5)
+      check.check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns healthy when diff since last check meets the minimum") {
+      // first call: total=0 (startup grace), second call: diff=100 >= 5
+      val check = KafkaConsumerRecordsConsumedHealthCheck(consumer(0.0, 100.0), minRecords = 5)
+      check.check().status shouldBe HealthStatus.Healthy
+      check.check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when diff since last check is below minimum") {
+      // first call: total=0 (grace), second: diff=100 OK, third: diff=2 < 5
+      val check = KafkaConsumerRecordsConsumedHealthCheck(consumer(0.0, 100.0, 102.0), minRecords = 5)
+      check.check().status shouldBe HealthStatus.Healthy  // grace
+      check.check().status shouldBe HealthStatus.Healthy  // diff=100
+      check.check().status shouldBe HealthStatus.Unhealthy // diff=2
+   }
+
+   test("lastTotal is updated between checks so diff is relative to previous call") {
+      // Totals: 0 → 10 → 12 → 20. With minRecords=5: diffs are 10, 2, 8.
+      val check = KafkaConsumerRecordsConsumedHealthCheck(consumer(0.0, 10.0, 12.0, 20.0), minRecords = 5)
+      check.check().status shouldBe HealthStatus.Healthy   // total=0, grace
+      check.check().status shouldBe HealthStatus.Healthy   // diff=10 >= 5
+      check.check().status shouldBe HealthStatus.Unhealthy // diff=2  <  5
+      check.check().status shouldBe HealthStatus.Healthy   // diff=8 >= 5
+   }
+})


### PR DESCRIPTION
## Summary

Three bugs, all in the same method:

1. **Inverted diff** — `diff = lastTotal - total` should be `total - lastTotal`. The delta was always negative.
2. **`lastTotal` never updated** — every check measured against 0, not the previous observation. Added `lastTotal = total` after computing the diff.
3. **Wrong threshold comparison** — the condition tested `total < minRecords` (comparing the cumulative Kafka counter) instead of `diff < minRecords` (the per-interval count), contradicting the documented intent: *"minimum number of records between invocations"*.

Also adds `@Volatile` to `lastTotal` for safe visibility across coroutine dispatchers.

## Tests added

`KafkaConsumerRecordsConsumedHealthCheckTest` — mockk-based unit tests:
- Grace period (total == 0) → healthy
- Diff meets minimum → healthy
- Diff below minimum → unhealthy
- Across multiple checks, each diff is measured relative to the *previous* observation (the key regression test for bug 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)