### PR TITLE
Fix KafkaProducerCountHealthCheck metric parsing and add @Volatile

### DIFF
--- a/cohort-kafka/build.gradle.kts
+++ b/cohort-kafka/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
 dependencies {
    implementation(projects.cohortApi)
    implementation(libs.kafka.client)
+   testImplementation(libs.mockk)
 }

--- a/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaProducerCountHealthCheck.kt
+++ b/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaProducerCountHealthCheck.kt
@@ -2,6 +2,7 @@ package com.sksamuel.cohort.kafka
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
+import kotlin.math.roundToLong
 import org.apache.kafka.clients.producer.Producer
 
 /**
@@ -19,14 +20,14 @@ class KafkaProducerCountHealthCheck(
 
    private val metricName = "record-send-total"
 
-   private var lastTotal: Long = -1
+   @Volatile private var lastTotal: Long = -1
 
    override suspend fun check(): HealthCheckResult {
 
       val metric = producer.metrics().values.firstOrNull { it.metricName().name() == metricName }
          ?: return HealthCheckResult.unhealthy("Could not locate kafka metric '${metricName}'", null)
 
-      val total = metric.metricValue().toString().toLongOrNull() ?: 0
+      val total = metric.metricValue().toString().toDoubleOrNull()?.roundToLong() ?: 0L
 
       // first time
       return if (lastTotal == -1L) {

--- a/cohort-kafka/src/test/kotlin/com/sksamuel/cohort/kafka/KafkaProducerCountHealthCheckTest.kt
+++ b/cohort-kafka/src/test/kotlin/com/sksamuel/cohort/kafka/KafkaProducerCountHealthCheckTest.kt
@@ -1,45 +1,52 @@
-//package com.sksamuel.cohort.kafka
-//
-//import com.sksamuel.cohort.HealthStatus
-//import io.kotest.core.extensions.install
-//import io.kotest.core.spec.style.FunSpec
-//import io.kotest.extensions.testcontainers.kafka.KafkaContainerExtension
-//import io.kotest.extensions.testcontainers.kafka.admin
-//import io.kotest.extensions.testcontainers.kafka.producer
-//import io.kotest.matchers.shouldBe
-//import kotlinx.coroutines.delay
-//import kotlinx.coroutines.isActive
-//import kotlinx.coroutines.launch
-//import org.apache.kafka.clients.admin.NewTopic
-//import org.apache.kafka.clients.producer.ProducerRecord
-//import org.apache.kafka.common.utils.Bytes
-//import org.testcontainers.containers.KafkaContainer
-//import org.testcontainers.utility.DockerImageName
-//import kotlin.time.Duration.Companion.seconds
-//
-//class KafkaProducerCountHealthCheckTest : FunSpec({
-//
-//   val kafka = install(KafkaContainerExtension(KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka"))))
-//
-//   test("health check should pass while the consumer is active") {
-//
-//      kafka.admin().use { it.createTopics(listOf(NewTopic("mytopic", 1, 1))).all().get() }
-//      val producer = kafka.producer()
-//
-//      val job = launch {
-//         while (isActive) {
-//            delay(10)
-//            producer.send(ProducerRecord("mytopic", Bytes.wrap(byteArrayOf()), Bytes.wrap(byteArrayOf())))
-//         }
-//      }
-//
-//      val healthcheck = KafkaProducerCountHealthCheck(producer, 80)
-//      delay(1.seconds) // should have sent ~ 100
-//      healthcheck.check().status shouldBe HealthStatus.Healthy
-//      job.cancel()
-//      delay(1.seconds) // now should be zero
-//      healthcheck.check().status shouldBe HealthStatus.Unhealthy
-//
-//      producer.close()
-//   }
-//})
+package com.sksamuel.cohort.kafka
+
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.apache.kafka.clients.producer.Producer
+import org.apache.kafka.common.Metric
+import org.apache.kafka.common.MetricName
+
+class KafkaProducerCountHealthCheckTest : FunSpec({
+
+   fun producer(vararg totals: Double): Producer<*, *> {
+      val producer = mockk<Producer<*, *>>()
+      val metricName = MetricName("record-send-total", "producer-metrics", "", emptyMap())
+      val responses = totals.map { value ->
+         val metric = mockk<Metric>()
+         every { metric.metricName() } returns metricName
+         every { metric.metricValue() } returns value
+         mapOf(metricName to metric)
+      }
+      every { producer.metrics() } returnsMany responses
+      return producer
+   }
+
+   test("returns healthy on the first check (initial scan)") {
+      val check = KafkaProducerCountHealthCheck(producer(50.0), min = 10)
+      check.check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns healthy when diff since last check meets the minimum") {
+      val check = KafkaProducerCountHealthCheck(producer(50.0, 100.0), min = 10)
+      check.check().status shouldBe HealthStatus.Healthy  // initial scan
+      check.check().status shouldBe HealthStatus.Healthy  // diff=50 >= 10
+   }
+
+   test("returns unhealthy when diff since last check is below minimum") {
+      val check = KafkaProducerCountHealthCheck(producer(50.0, 53.0), min = 10)
+      check.check().status shouldBe HealthStatus.Healthy   // initial scan
+      check.check().status shouldBe HealthStatus.Unhealthy // diff=3 < 10
+   }
+
+   test("diff is measured relative to the previous observation, not from zero") {
+      // Totals: 100 (initial), 115 (diff=15 OK), 117 (diff=2 fail), 130 (diff=13 OK)
+      val check = KafkaProducerCountHealthCheck(producer(100.0, 115.0, 117.0, 130.0), min = 10)
+      check.check().status shouldBe HealthStatus.Healthy   // initial
+      check.check().status shouldBe HealthStatus.Healthy   // diff=15
+      check.check().status shouldBe HealthStatus.Unhealthy // diff=2
+      check.check().status shouldBe HealthStatus.Healthy   // diff=13
+   }
+})


### PR DESCRIPTION
## Summary

Two bugs:

1. **Metric parsing** — `toLongOrNull()` silently returns `null` for Kafka's Double-valued metric (e.g. `"50.0"` is not a valid Long). `total` was always 0, making the diff always 0. Fixed to `toDoubleOrNull()?.roundToLong()`, consistent with the consumer-side checks.
2. **Missing `@Volatile`** — `lastTotal` is read and written from coroutine code that may run on different dispatchers. Added `@Volatile` for safe cross-thread visibility.

## Tests added

`KafkaProducerCountHealthCheckTest` — mockk-based unit tests:
- Initial scan → healthy
- Diff meets minimum → healthy
- Diff below minimum → unhealthy
- Diff is relative to the previous observation, not from zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)