### PR TITLE
Fix AWS client leaks by reusing clients

### DIFF
--- a/cohort-aws-dynamo/build.gradle.kts
+++ b/cohort-aws-dynamo/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
 dependencies {
    implementation(projects.cohortApi)
    api(libs.aws.java.sdk.dynamodb)
+   testImplementation(libs.mockk)
 }

--- a/cohort-aws-dynamo/src/main/kotlin/com/sksamuel/cohort/aws/dynamo/DynamoDBHealthCheck.kt
+++ b/cohort-aws-dynamo/src/main/kotlin/com/sksamuel/cohort/aws/dynamo/DynamoDBHealthCheck.kt
@@ -12,20 +12,19 @@ import kotlinx.coroutines.runInterruptible
  * by connecting and requesting to list the tables (limit of 1).
  */
 class DynamoDBHealthCheck(
-   val createClient: () -> AmazonDynamoDB = { AmazonDynamoDBClient.builder().build() },
+   private val client: AmazonDynamoDB,
    override val name: String = "aws_dynamodb",
 ) : HealthCheck {
 
-   private fun <T> AmazonDynamoDB.use(f: (AmazonDynamoDB) -> T): Result<T> {
-      val result = runCatching { f(this) }
-      this.shutdown()
-      return result
-   }
+   constructor(
+      createClient: () -> AmazonDynamoDB = { AmazonDynamoDBClient.builder().build() },
+      name: String = "aws_dynamodb",
+   ) : this(createClient(), name)
 
    override suspend fun check(): HealthCheckResult {
       return runInterruptible(Dispatchers.IO) {
-         createClient().use {
-            it.listTables(1)
+         runCatching {
+            client.listTables(1)
          }
       }.fold(
          { HealthCheckResult.healthy("DynamoDB access successful") },

--- a/cohort-aws-dynamo/src/test/kotlin/com/sksamuel/cohort/aws/dynamo/DynamoDBHealthCheckTest.kt
+++ b/cohort-aws-dynamo/src/test/kotlin/com/sksamuel/cohort/aws/dynamo/DynamoDBHealthCheckTest.kt
@@ -1,0 +1,28 @@
+package com.sksamuel.cohort.aws.dynamo
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class DynamoDBHealthCheckTest : FunSpec({
+
+   test("should be healthy if listTables succeeds") {
+      val client = mockk<AmazonDynamoDB>()
+      every { client.listTables(any<Int>()) } returns null
+      val check = DynamoDBHealthCheck(client)
+      check.check().status shouldBe HealthStatus.Healthy
+      verify(exactly = 0) { client.shutdown() }
+   }
+
+   test("should be unhealthy if listTables fails") {
+      val client = mockk<AmazonDynamoDB>()
+      every { client.listTables(any<Int>()) } throws RuntimeException("foo")
+      val check = DynamoDBHealthCheck(client)
+      check.check().status shouldBe HealthStatus.Unhealthy
+      verify(exactly = 0) { client.shutdown() }
+   }
+})

--- a/cohort-aws-s3/build.gradle.kts
+++ b/cohort-aws-s3/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
 dependencies {
    implementation(projects.cohortApi)
    api(libs.aws.java.sdk.s3)
+   testImplementation(libs.mockk)
 }

--- a/cohort-aws-s3/src/main/kotlin/com/sksamuel/cohort/aws/s3/S3ReadBucketHealthCheck.kt
+++ b/cohort-aws-s3/src/main/kotlin/com/sksamuel/cohort/aws/s3/S3ReadBucketHealthCheck.kt
@@ -15,24 +15,24 @@ import kotlinx.coroutines.runInterruptible
  */
 class S3ReadBucketHealthCheck(
    private val bucketName: String,
-   val createClient: () -> AmazonS3 = { AmazonS3Client.builder().build() },
+   private val client: AmazonS3,
    override val name: String = "aws_s3_bucket",
 ) : HealthCheck {
 
-   private suspend fun use(client: AmazonS3): Result<HeadBucketResult> {
+   constructor(
+      bucketName: String,
+      createClient: () -> AmazonS3 = { AmazonS3Client.builder().build() },
+      name: String = "aws_s3_bucket",
+   ) : this(bucketName, createClient(), name)
+
+   override suspend fun check(): HealthCheckResult {
       return runInterruptible(Dispatchers.IO) {
          runCatching {
             client.headBucket(HeadBucketRequest(bucketName))
          }
-      }.also { client.shutdown() }
-   }
-
-   override suspend fun check(): HealthCheckResult {
-      return runCatching { createClient() }
-         .flatMap { use(it) }
-         .fold(
-            { HealthCheckResult.healthy("Connected to bucket $bucketName") },
-            { HealthCheckResult.unhealthy("Could not connect to bucket $bucketName", it) }
-         )
+      }.fold(
+         { HealthCheckResult.healthy("Connected to bucket $bucketName") },
+         { HealthCheckResult.unhealthy("Could not connect to bucket $bucketName", it) }
+      )
    }
 }

--- a/cohort-aws-s3/src/main/kotlin/com/sksamuel/cohort/aws/s3/S3WriteBucketHealthCheck.kt
+++ b/cohort-aws-s3/src/main/kotlin/com/sksamuel/cohort/aws/s3/S3WriteBucketHealthCheck.kt
@@ -14,26 +14,29 @@ import kotlin.random.Random
  */
 class S3WriteBucketHealthCheck(
    private val bucketName: String,
-   val createClient: () -> AmazonS3 = { AmazonS3Client.builder().build() },
+   private val client: AmazonS3,
    override val name: String = "aws_s3_bucket_write"
 ) : HealthCheck {
 
-   private suspend fun use(client: AmazonS3): Result<Unit> {
+   constructor(
+      bucketName: String,
+      createClient: () -> AmazonS3 = { AmazonS3Client.builder().build() },
+      name: String = "aws_s3_bucket_write"
+   ) : this(bucketName, createClient(), name)
+
+   override suspend fun check(): HealthCheckResult {
       return runInterruptible(Dispatchers.IO) {
          runCatching {
             val key = "cohort_" + Random.nextInt(0, Integer.MAX_VALUE)
-            client.putObject(bucketName, key, "test")
-            client.deleteObject(bucketName, key)
+            try {
+               client.putObject(bucketName, key, "test")
+            } finally {
+               runCatching { client.deleteObject(bucketName, key) }
+            }
          }
-      }.also { client.shutdown() }
-   }
-
-   override suspend fun check(): HealthCheckResult {
-      return runCatching { createClient() }
-         .flatMap { use(it) }
-         .fold(
-            { HealthCheckResult.healthy("Put operation to bucket $bucketName successful") },
-            { HealthCheckResult.unhealthy("Could not write to bucket $bucketName", it) }
-         )
+      }.fold(
+         { HealthCheckResult.healthy("Put operation to bucket $bucketName successful") },
+         { HealthCheckResult.unhealthy("Could not write to bucket $bucketName", it) }
+      )
    }
 }

--- a/cohort-aws-s3/src/test/kotlin/com/sksamuel/cohort/aws/s3/S3ReadBucketHealthCheckTest.kt
+++ b/cohort-aws-s3/src/test/kotlin/com/sksamuel/cohort/aws/s3/S3ReadBucketHealthCheckTest.kt
@@ -1,0 +1,28 @@
+package com.sksamuel.cohort.aws.s3
+
+import com.amazonaws.services.s3.AmazonS3
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class S3ReadBucketHealthCheckTest : FunSpec({
+
+   test("should be healthy if headBucket succeeds") {
+      val client = mockk<AmazonS3>()
+      every { client.headBucket(any()) } returns null
+      val check = S3ReadBucketHealthCheck("mybucket", client)
+      check.check().status shouldBe HealthStatus.Healthy
+      verify(exactly = 0) { client.shutdown() }
+   }
+
+   test("should be unhealthy if headBucket fails") {
+      val client = mockk<AmazonS3>()
+      every { client.headBucket(any()) } throws RuntimeException("foo")
+      val check = S3ReadBucketHealthCheck("mybucket", client)
+      check.check().status shouldBe HealthStatus.Unhealthy
+      verify(exactly = 0) { client.shutdown() }
+   }
+})

--- a/cohort-aws-s3/src/test/kotlin/com/sksamuel/cohort/aws/s3/S3WriteBucketHealthCheckTest.kt
+++ b/cohort-aws-s3/src/test/kotlin/com/sksamuel/cohort/aws/s3/S3WriteBucketHealthCheckTest.kt
@@ -1,0 +1,34 @@
+package com.sksamuel.cohort.aws.s3
+
+import com.amazonaws.services.s3.AmazonS3
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class S3WriteBucketHealthCheckTest : FunSpec({
+
+   test("should be healthy if write succeeds") {
+      val client = mockk<AmazonS3>()
+      every { client.putObject(any(), any(), any<String>()) } returns null
+      every { client.deleteObject(any(), any()) } returns Unit
+      val check = S3WriteBucketHealthCheck("mybucket", client)
+      check.check().status shouldBe HealthStatus.Healthy
+      verify(exactly = 1) { client.putObject("mybucket", any(), "test") }
+      verify(exactly = 1) { client.deleteObject("mybucket", any()) }
+      verify(exactly = 0) { client.shutdown() }
+   }
+
+   test("should be unhealthy if put fails") {
+      val client = mockk<AmazonS3>()
+      every { client.putObject(any(), any(), any<String>()) } throws RuntimeException("foo")
+      every { client.deleteObject(any(), any()) } returns Unit
+      val check = S3WriteBucketHealthCheck("mybucket", client)
+      check.check().status shouldBe HealthStatus.Unhealthy
+      verify(exactly = 1) { client.putObject("mybucket", any(), "test") }
+      verify(exactly = 1) { client.deleteObject("mybucket", any()) }
+      verify(exactly = 0) { client.shutdown() }
+   }
+})

--- a/cohort-aws-sns/build.gradle.kts
+++ b/cohort-aws-sns/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
 dependencies {
    implementation(projects.cohortApi)
    api(libs.aws.java.sdk.sns)
+   testImplementation(libs.mockk)
 }

--- a/cohort-aws-sns/src/main/kotlin/com/sksamuel/cohort/aws/sns/SNSHealthCheck.kt
+++ b/cohort-aws-sns/src/main/kotlin/com/sksamuel/cohort/aws/sns/SNSHealthCheck.kt
@@ -11,17 +11,17 @@ import com.sksamuel.tabby.results.flatMap
  * A Cohort [HealthCheck] that checks for connectivity to an AWS SNS by listing topics.
  */
 class SNSHealthCheck(
-   val createClient: () -> AmazonSNS = { AmazonSNSClient.builder().build() },
+   private val client: AmazonSNS,
    override val name: String = "aws_sns_topic",
 ) : HealthCheck {
 
-   private fun use(client: AmazonSNS): Result<ListTopicsResult> {
-      return runCatching { client.listTopics() }.also { client.shutdown() }
-   }
+   constructor(
+      createClient: () -> AmazonSNS = { AmazonSNSClient.builder().build() },
+      name: String = "aws_sns_topic",
+   ) : this(createClient(), name)
 
    override suspend fun check(): HealthCheckResult {
-      return runCatching { createClient() }
-         .flatMap { use(it) }
+      return runCatching { client.listTopics() }
          .fold(
             { HealthCheckResult.healthy("SNS access confirmed") },
             { HealthCheckResult.unhealthy("Could not connect to SNS", it) }

--- a/cohort-aws-sns/src/test/kotlin/com/sksamuel/cohort/aws/sns/SNSHealthCheckTest.kt
+++ b/cohort-aws-sns/src/test/kotlin/com/sksamuel/cohort/aws/sns/SNSHealthCheckTest.kt
@@ -1,0 +1,28 @@
+package com.sksamuel.cohort.aws.sns
+
+import com.amazonaws.services.sns.AmazonSNS
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class SNSHealthCheckTest : FunSpec({
+
+   test("should be healthy if listTopics succeeds") {
+      val client = mockk<AmazonSNS>()
+      every { client.listTopics() } returns null
+      val check = SNSHealthCheck(client)
+      check.check().status shouldBe HealthStatus.Healthy
+      verify(exactly = 0) { client.shutdown() }
+   }
+
+   test("should be unhealthy if listTopics fails") {
+      val client = mockk<AmazonSNS>()
+      every { client.listTopics() } throws RuntimeException("foo")
+      val check = SNSHealthCheck(client)
+      check.check().status shouldBe HealthStatus.Unhealthy
+      verify(exactly = 0) { client.shutdown() }
+   }
+})

--- a/cohort-aws-sqs/build.gradle.kts
+++ b/cohort-aws-sqs/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
 dependencies {
    implementation(projects.cohortApi)
    api(libs.aws.java.sdk.sqs)
+   testImplementation(libs.mockk)
 }

--- a/cohort-aws-sqs/src/main/kotlin/com/sksamuel/cohort/aws/sqs/SQSQueueHealthCheck.kt
+++ b/cohort-aws-sqs/src/main/kotlin/com/sksamuel/cohort/aws/sqs/SQSQueueHealthCheck.kt
@@ -12,17 +12,18 @@ import com.sksamuel.tabby.results.flatMap
  */
 class SQSQueueHealthCheck(
    private val queue: String,
-   val createClient: () -> AmazonSQS = { AmazonSQSClient.builder().build() },
+   private val client: AmazonSQS,
    override val name: String = "aws_sqs_queue",
 ) : HealthCheck {
 
-   private fun use(client: AmazonSQS): Result<GetQueueUrlResult> {
-      return runCatching { client.getQueueUrl(queue) }.also { client.shutdown() }
-   }
+   constructor(
+      queue: String,
+      createClient: () -> AmazonSQS = { AmazonSQSClient.builder().build() },
+      name: String = "aws_sqs_queue",
+   ) : this(queue, createClient(), name)
 
    override suspend fun check(): HealthCheckResult {
-      return runCatching { createClient() }
-         .flatMap { use(it) }
+      return runCatching { client.getQueueUrl(queue) }
          .fold(
             { HealthCheckResult.healthy("SQS queue access confirmed $queue") },
             { HealthCheckResult.unhealthy("Could not connect to SQS queue $queue", it) }

--- a/cohort-aws-sqs/src/test/kotlin/com/sksamuel/cohort/aws/sqs/SQSQueueHealthCheckTest.kt
+++ b/cohort-aws-sqs/src/test/kotlin/com/sksamuel/cohort/aws/sqs/SQSQueueHealthCheckTest.kt
@@ -1,0 +1,28 @@
+package com.sksamuel.cohort.aws.sqs
+
+import com.amazonaws.services.sqs.AmazonSQS
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class SQSQueueHealthCheckTest : FunSpec({
+
+   test("should be healthy if getQueueUrl succeeds") {
+      val client = mockk<AmazonSQS>()
+      every { client.getQueueUrl(any<String>()) } returns null
+      val check = SQSQueueHealthCheck("myqueue", client)
+      check.check().status shouldBe HealthStatus.Healthy
+      verify(exactly = 0) { client.shutdown() }
+   }
+
+   test("should be unhealthy if getQueueUrl fails") {
+      val client = mockk<AmazonSQS>()
+      every { client.getQueueUrl(any<String>()) } throws RuntimeException("foo")
+      val check = SQSQueueHealthCheck("myqueue", client)
+      check.check().status shouldBe HealthStatus.Unhealthy
+      verify(exactly = 0) { client.shutdown() }
+   }
+})


### PR DESCRIPTION
Health checks for S3, DynamoDB, SNS, and SQS were creating and shutting down a new AWS SDK client for every check invocation. This PR refactors them to reuse clients and adds tests.