### PR TITLE
Add global health check timeout and improve registry shutdown

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
@@ -39,6 +39,7 @@ class HealthCheckRegistry(
 
    var startUnhealthy: Boolean = true
    var logUnhealthy: Boolean = true
+   var checkTimeout: Duration = 10.seconds
 
    init {
       Runtime.getRuntime().addShutdownHook(Thread {
@@ -183,7 +184,9 @@ class HealthCheckRegistry(
    private suspend fun run(name: String) {
       val check = checks[name] ?: return
       try {
-         val result = check.check()
+         val result = withTimeout(checkTimeout) {
+            check.check()
+         }
          notifySubscribers(name, check, result)
          notifyListeners(name, result)
          when (result.status) {
@@ -270,6 +273,9 @@ class HealthCheckRegistry(
    override fun close() {
       scope.cancel()
       scheduler.shutdown()
+      runCatching {
+         scheduler.awaitTermination(5, TimeUnit.SECONDS)
+      }
    }
 }
 

--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/HealthCheckRegistryTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/HealthCheckRegistryTest.kt
@@ -84,4 +84,18 @@ class HealthCheckRegistryTest : FunSpec({
          }
       }
    }
+
+   test("health check should timeout") {
+      val reg = HealthCheckRegistry {
+         checkTimeout = 100.milliseconds
+         register("timeout", {
+            delay(500.milliseconds)
+            HealthCheckResult.healthy("ok")
+         }, 1.milliseconds, 1.milliseconds)
+      }
+      eventually(1.seconds) {
+         reg.status().healthchecks["timeout"]?.result?.status shouldBe HealthStatus.Unhealthy
+         reg.status().healthchecks["timeout"]?.result?.message shouldBe "timeout failed due to kotlinx.coroutines.TimeoutCancellationException"
+      }
+   }
 })


### PR DESCRIPTION
Adds a configurable timeout to all health checks in the registry and ensures the scheduler is properly shut down during registry close.