### PR TITLE
Stop closing Jedis connections after health checks

### DIFF
--- a/cohort-jedis/src/main/kotlin/com/sksamuel/cohort/redis/RedisClusterHealthCheck.kt
+++ b/cohort-jedis/src/main/kotlin/com/sksamuel/cohort/redis/RedisClusterHealthCheck.kt
@@ -53,7 +53,7 @@ class RedisClusterHealthCheck(
    override suspend fun check(): HealthCheckResult {
       return runInterruptible(Dispatchers.IO) {
          runCatching {
-            jedis.use { command(it) }
+            command(jedis)
          }.getOrElse {
             HealthCheckResult.unhealthy("Could not connect to redis cluster", it)
          }

--- a/cohort-jedis/src/main/kotlin/com/sksamuel/cohort/redis/RedisConnectionHealthCheck.kt
+++ b/cohort-jedis/src/main/kotlin/com/sksamuel/cohort/redis/RedisConnectionHealthCheck.kt
@@ -50,7 +50,7 @@ class RedisConnectionHealthCheck(
    override suspend fun check(): HealthCheckResult {
       return runInterruptible(Dispatchers.IO) {
          runCatching {
-            jedis.connection.use { command(it) }
+            command(jedis.connection)
          }.getOrElse {
             HealthCheckResult.unhealthy("Could not connect to Redis", it)
          }

--- a/cohort-jedis/src/test/kotlin/com/sksamuel/cohort/redis/RedisClusterHealthCheckTest.kt
+++ b/cohort-jedis/src/test/kotlin/com/sksamuel/cohort/redis/RedisClusterHealthCheckTest.kt
@@ -1,0 +1,29 @@
+package com.sksamuel.cohort.redis
+
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import redis.clients.jedis.JedisCluster
+
+class RedisClusterHealthCheckTest : FunSpec({
+
+   test("should be healthy if nodes > 0") {
+      val jedis = mockk<JedisCluster>()
+      every { jedis.clusterNodes } returns mapOf("foo" to mockk())
+      val check = RedisClusterHealthCheck(jedis)
+      check.check().status shouldBe HealthStatus.Healthy
+      check.check().status shouldBe HealthStatus.Healthy
+      verify(exactly = 0) { jedis.close() }
+   }
+
+   test("should be unhealthy if nodes == 0") {
+      val jedis = mockk<JedisCluster>()
+      every { jedis.clusterNodes } returns emptyMap()
+      val check = RedisClusterHealthCheck(jedis)
+      check.check().status shouldBe HealthStatus.Unhealthy
+      verify(exactly = 0) { jedis.close() }
+   }
+})

--- a/cohort-jedis/src/test/kotlin/com/sksamuel/cohort/redis/RedisConnectionHealthCheckTest.kt
+++ b/cohort-jedis/src/test/kotlin/com/sksamuel/cohort/redis/RedisConnectionHealthCheckTest.kt
@@ -5,6 +5,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import redis.clients.jedis.Connection
 import redis.clients.jedis.Jedis
 
@@ -24,5 +25,18 @@ class RedisConnectionHealthCheckTest : FunSpec({
 
    test("returns unhealthy when ping fails") {
       RedisConnectionHealthCheck(jedisWithPingResult(false)).check().status shouldBe HealthStatus.Unhealthy
+   }
+
+   test("should not close connection so that subsequent calls work") {
+      val conn = mockk<Connection>(relaxed = true)
+      every { conn.ping() } returns true
+      val jedis = mockk<Jedis>()
+      every { jedis.connection } returns conn
+
+      val check = RedisConnectionHealthCheck(jedis)
+      check.check().status shouldBe HealthStatus.Healthy
+      check.check().status shouldBe HealthStatus.Healthy
+
+      verify(exactly = 0) { conn.close() }
    }
 })


### PR DESCRIPTION
Fixes a bug where Jedis and JedisCluster connections were being closed after a single check, breaking subsequent check attempts. Includes new tests.