### PR TITLE
Fix inverted logic in MaxFileDescriptorsHealthCheck

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheck.kt
@@ -8,9 +8,9 @@ import java.lang.management.ManagementFactory
 /**
  * A Cohort [HealthCheck] for the number of max file descriptors.
  *
- * The check is considered healthy if the max count is <= [requiredMaxDescriptors].
+ * The check is considered healthy if the max count is >= [minMaxDescriptors].
  */
-class MaxFileDescriptorsHealthCheck(private val requiredMaxDescriptors: Int) : HealthCheck {
+class MaxFileDescriptorsHealthCheck(private val minMaxDescriptors: Int) : HealthCheck {
 
   private val bean = ManagementFactory.getOperatingSystemMXBean() as UnixOperatingSystemMXBean
 
@@ -18,8 +18,8 @@ class MaxFileDescriptorsHealthCheck(private val requiredMaxDescriptors: Int) : H
 
   override suspend fun check(): HealthCheckResult {
     val files = bean.maxFileDescriptorCount
-    val msg = "Max file descriptors $files [required at least $requiredMaxDescriptors]"
-    return if (files < requiredMaxDescriptors) {
+    val msg = "Max file descriptors $files [required at least $minMaxDescriptors]"
+    return if (files >= minMaxDescriptors) {
       HealthCheckResult.healthy(msg)
     } else {
       HealthCheckResult.unhealthy(msg, null)


### PR DESCRIPTION
Corrects the logic to ensure the system is healthy only when the max file descriptor limit meets the required minimum.