### PR TITLE
Add timeouts to Kafka, Lettuce, and Elastic health checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ project/boot/
 project/plugins/project/
 credentials.sbt
 .gradle
+
+# gemini-cli settings
+.gemini/
+
+# GitHub App credentials
+gha-creds-*.json

--- a/cohort-elastic/src/main/kotlin/com/sksamuel/cohort/elastic/ElasticClusterHealthCheck.kt
+++ b/cohort-elastic/src/main/kotlin/com/sksamuel/cohort/elastic/ElasticClusterHealthCheck.kt
@@ -26,8 +26,10 @@ class ElasticClusterHealthCheck(
   override suspend fun check(): HealthCheckResult {
     return runCatching {
 
-      val health = withContext(Dispatchers.IO) {
-        client.cluster().health(ClusterHealthRequest(), RequestOptions.DEFAULT)
+      val health = withTimeout(5.seconds) {
+        withContext(Dispatchers.IO) {
+          client.cluster().health(ClusterHealthRequest(), RequestOptions.DEFAULT)
+        }
       }
 
       val status = health.status

--- a/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaClusterHealthCheck.kt
+++ b/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaClusterHealthCheck.kt
@@ -15,18 +15,20 @@ class KafkaClusterHealthCheck(
 ) : HealthCheck {
 
    override suspend fun check(): HealthCheckResult {
-      return try {
-         val clusterResult = admin.describeCluster()
-         val controller = clusterResult.controller().toCompletionStage().await()
-         val nodes = clusterResult.nodes().toCompletionStage().await()
+      return withTimeout(5.seconds) {
+         try {
+            val clusterResult = admin.describeCluster()
+            val controller = clusterResult.controller().toCompletionStage().await()
+            val nodes = clusterResult.nodes().toCompletionStage().await()
 
-         when {
-            nodes.isEmpty() -> HealthCheckResult.unhealthy("Kafka cluster is showing no nodes", null)
-            controller == null -> HealthCheckResult.unhealthy("Kafka cluster returned without controller", null)
-            else -> HealthCheckResult.healthy("Connected to kafka cluster with controller ${controller.host()} and ${nodes.size} node(s)")
+            when {
+               nodes.isEmpty() -> HealthCheckResult.unhealthy("Kafka cluster is showing no nodes", null)
+               controller == null -> HealthCheckResult.unhealthy("Kafka cluster returned without controller", null)
+               else -> HealthCheckResult.healthy("Connected to kafka cluster with controller ${controller.host()} and ${nodes.size} node(s)")
+            }
+         } catch (t: Throwable) {
+            HealthCheckResult.unhealthy("Could not connect to kafka cluster", t)
          }
-      } catch (t: Throwable) {
-         HealthCheckResult.unhealthy("Could not connect to kafka cluster", t)
       }
    }
 }

--- a/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaTopicHealthCheck.kt
+++ b/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaTopicHealthCheck.kt
@@ -15,15 +15,16 @@ class KafkaTopicHealthCheck(
 ) : HealthCheck {
 
    override suspend fun check(): HealthCheckResult {
+      return withTimeout(5.seconds) {
+         val descriptionMap = runCatching {
+            admin.describeTopics(listOf(topic)).allTopicNames().toCompletionStage().await()
+         }.getOrElse { emptyMap() }
 
-      val descriptionMap = runCatching {
-         admin.describeTopics(listOf(topic)).allTopicNames().toCompletionStage().await()
-      }.getOrElse { emptyMap() }
-
-      val topicDescription = descriptionMap[topic]
-      return if (topicDescription == null)
-         HealthCheckResult.unhealthy("Topic $topic does not exist on kafka cluster", null)
-      else
-         HealthCheckResult.healthy("Kafka topic $topicDescription confirmed (${topicDescription.partitions().size} partitions)")
+         val topicDescription = descriptionMap[topic]
+         if (topicDescription == null)
+            HealthCheckResult.unhealthy("Topic $topic does not exist on kafka cluster", null)
+         else
+            HealthCheckResult.healthy("Kafka topic $topicDescription confirmed (${topicDescription.partitions().size} partitions)")
+      }
    }
 }

--- a/cohort-lettuce/src/main/kotlin/com/sksamuel/cohort/lettuce/RedisHealthCheck.kt
+++ b/cohort-lettuce/src/main/kotlin/com/sksamuel/cohort/lettuce/RedisHealthCheck.kt
@@ -38,7 +38,9 @@ class RedisHealthCheck<K, V>(
 
    override suspend fun check(): HealthCheckResult {
       return runCatching {
-         command(conn)
+         withTimeout(5.seconds) {
+            command(conn)
+         }
          HealthCheckResult.healthy("Redis command successful")
       }.getOrElse { HealthCheckResult.unhealthy("Redis command failure", it) }
    }


### PR DESCRIPTION
Wraps long-running network operations in Kafka, Lettuce, and Elastic health checks with a 5-second timeout to prevent hanging.