### PR TITLE
Fix FreememHealthCheck Int overflow and PulsarHealthCheck no-op connectivity check

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/FreememHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/FreememHealthCheck.kt
@@ -10,11 +10,11 @@ import java.lang.management.MemoryPoolMXBean
  *
  * The check is considered healthy if the amount of free memory is above [minFreeBytes].
  */
-class FreememHealthCheck(private val minFreeBytes: Int) : HealthCheck {
+class FreememHealthCheck(private val minFreeBytes: Long) : HealthCheck {
 
   companion object {
-    fun mb(mb: Int) = FreememHealthCheck(mb * 1024 * 1024)
-    fun gb(gb: Int) = FreememHealthCheck(gb * 1024 * 1024 * 1024)
+    fun mb(mb: Int) = FreememHealthCheck(mb.toLong() * 1024L * 1024L)
+    fun gb(gb: Int) = FreememHealthCheck(gb.toLong() * 1024L * 1024L * 1024L)
   }
 
   override val name: String = "free_mem"

--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/memory/FreememHealthCheckTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/memory/FreememHealthCheckTest.kt
@@ -1,0 +1,30 @@
+package com.sksamuel.cohort.memory
+
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class FreememHealthCheckTest : FunSpec({
+
+   test("returns healthy when free memory exceeds the minimum") {
+      FreememHealthCheck(1L).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when minimum exceeds available memory") {
+      FreememHealthCheck(Long.MAX_VALUE).check().status shouldBe HealthStatus.Unhealthy
+   }
+
+   test("mb factory does not overflow for large values") {
+      val check = FreememHealthCheck.mb(2048)
+      // 2048 * 1024 * 1024 = 2147483648 — overflows Int but must be positive as Long
+      check shouldNotBe null
+      FreememHealthCheck.mb(2048).check() // must not throw
+   }
+
+   test("gb factory does not overflow") {
+      val check = FreememHealthCheck.gb(2)
+      // 2 * 1024 * 1024 * 1024 = 2147483648 — overflows Int to negative, must be positive as Long
+      FreememHealthCheck.gb(2).check().status shouldBe HealthStatus.Unhealthy // 2 GB threshold exceeds JVM heap
+   }
+})

--- a/cohort-pulsar/src/main/kotlin/com/sksamuel/cohort/pulsar/PulsarHealthCheck.kt
+++ b/cohort-pulsar/src/main/kotlin/com/sksamuel/cohort/pulsar/PulsarHealthCheck.kt
@@ -19,7 +19,7 @@ class PulsarHealthCheck(
 
    override suspend fun check(): HealthCheckResult {
       return runCatching {
-         client.bookies()
+         client.clusters().getClusters()
          HealthCheckResult.healthy("Connected to Pulsar")
       }.getOrElse { HealthCheckResult.unhealthy("Could not connect to Pulsar", it) }
    }


### PR DESCRIPTION
## Summary

- **FreememHealthCheck**: `mb()` and `gb()` factory methods used `Int` arithmetic that silently overflowed to large negative values for inputs ≥ 2GB (e.g. `gb(2)` → `-2147483648` instead of `2147483648`). Because `freeMemory` (a positive `Long`) is never less than a large negative number, the health check always passed regardless of available memory. Fixed by casting to `Long` before multiplying: `mb.toLong() * 1024L * 1024L`.

- **PulsarHealthCheck**: `client.bookies()` returns a `Bookies` interface handle without making any network call to the Pulsar admin API — it is effectively a no-op, so the check always returned healthy regardless of whether the cluster was reachable. Fixed by calling `client.clusters().getClusters()` which makes an actual REST request.

## Test plan

- [ ] `FreememHealthCheck(1L).check()` returns Healthy (threshold well below available memory)
- [ ] `FreememHealthCheck(Long.MAX_VALUE).check()` returns Unhealthy (threshold exceeds any real heap)
- [ ] `FreememHealthCheck.mb(2048)` does not overflow (2048 × 1024 × 1024 = 2147483648 — fits in Long)
- [ ] `FreememHealthCheck.gb(2).check()` returns Unhealthy (2 GB threshold exceeds JVM heap)
- [ ] `PulsarHealthCheck` fix verified by code review (Pulsar admin lib compiled with Java 17; project targets Java 11, preventing test-time class loading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)