### PR TITLE
Fix four bugs in cohort-api health checks

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/db/DatabaseHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/db/DatabaseHealthCheck.kt
@@ -18,7 +18,7 @@ class DatabaseHealthCheck(
 ) : HealthCheck {
 
    override suspend fun check(): HealthCheckResult = ds.connection.use { conn ->
-      conn.createStatement().executeQuery(query)
+      conn.createStatement().use { it.executeQuery(query) }
       HealthCheckResult.healthy("Connected to database successfully")
    }
 }

--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/GarbageCollectionTimeCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/GarbageCollectionTimeCheck.kt
@@ -18,9 +18,9 @@ import kotlin.time.TimeSource
 class GarbageCollectionTimeCheck(private val maxGcTime: Int) : HealthCheck {
 
   private val beans = ManagementFactory.getGarbageCollectorMXBeans()
-  private var lastTime = 0L
+  @Volatile private var lastTime = 0L
   private val source = TimeSource.Monotonic
-  private var lastMark: TimeMark? = null
+  @Volatile private var lastMark: TimeMark? = null
 
   override val name: String = "garbage_collection_time"
 
@@ -34,7 +34,7 @@ class GarbageCollectionTimeCheck(private val maxGcTime: Int) : HealthCheck {
     val elapsed = lastMark?.elapsedNow()?.inWholeMilliseconds
     lastMark = source.markNow()
 
-    return if (elapsed == null) {
+    return if (elapsed == null || elapsed == 0L) {
       HealthCheckResult.healthy("GC Collection time was 0%")
     } else {
       val pc = (timeDiff / elapsed.toDouble()).roundToInt()

--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheck.kt
@@ -8,7 +8,7 @@ import java.lang.management.ManagementFactory
 /**
  * A Cohort [HealthCheck] for the number of max file descriptors.
  *
- * The check is considered healthy if the max count is <= [requiredMaxDescriptors].
+ * The check is considered healthy if the max count is >= [requiredMaxDescriptors].
  */
 class MaxFileDescriptorsHealthCheck(private val requiredMaxDescriptors: Int) : HealthCheck {
 
@@ -19,7 +19,7 @@ class MaxFileDescriptorsHealthCheck(private val requiredMaxDescriptors: Int) : H
   override suspend fun check(): HealthCheckResult {
     val files = bean.maxFileDescriptorCount
     val msg = "Max file descriptors $files [required at least $requiredMaxDescriptors]"
-    return if (files < requiredMaxDescriptors) {
+    return if (files >= requiredMaxDescriptors) {
       HealthCheckResult.healthy(msg)
     } else {
       HealthCheckResult.unhealthy(msg, null)

--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/OpenFileDescriptorsHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/OpenFileDescriptorsHealthCheck.kt
@@ -18,7 +18,7 @@ class OpenFileDescriptorsHealthCheck(private val maxOpenFileDescriptors: Int) : 
 
   override suspend fun check(): HealthCheckResult {
     val open = bean.openFileDescriptorCount
-    return if (open < maxOpenFileDescriptors) {
+    return if (open <= maxOpenFileDescriptors) {
       HealthCheckResult.healthy("Open file descriptor count within threshold [$open <= $maxOpenFileDescriptors]")
     } else {
       HealthCheckResult.unhealthy("Open file descriptors count above threshold [$open > $maxOpenFileDescriptors]", null)

--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/db/DatabaseHealthCheckTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/db/DatabaseHealthCheckTest.kt
@@ -1,0 +1,19 @@
+package com.sksamuel.cohort.db
+
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+@Suppress("DEPRECATION")
+class DatabaseHealthCheckTest : FunSpec({
+
+   test("returns healthy when default SELECT 1 query succeeds") {
+      DatabaseHealthCheck(createHikariDS()).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns healthy when a custom query succeeds") {
+      val ds = createHikariDS()
+      ds.connection.use { it.createStatement().executeUpdate("CREATE TABLE test_table (id int)") }
+      DatabaseHealthCheck(ds, query = "SELECT * FROM test_table").check().status shouldBe HealthStatus.Healthy
+   }
+})

--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/memory/GarbageCollectionTimeCheckTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/memory/GarbageCollectionTimeCheckTest.kt
@@ -1,0 +1,29 @@
+package com.sksamuel.cohort.memory
+
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+@OptIn(kotlin.time.ExperimentalTime::class)
+class GarbageCollectionTimeCheckTest : FunSpec({
+
+   test("returns healthy on first invocation when elapsed time is unknown") {
+      GarbageCollectionTimeCheck(0).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns healthy on second invocation when GC time is well within threshold") {
+      val check = GarbageCollectionTimeCheck(100) // 100% GC time threshold
+      check.check() // first call sets the baseline — result is always healthy
+      check.check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when GC time threshold is zero and GC has run") {
+      // Force GC and then check with 0% threshold
+      val check = GarbageCollectionTimeCheck(0)
+      check.check() // establish baseline
+      System.gc()
+      // Subsequent calls compute percentage; with maxGcTime=0 any GC time is unhealthy.
+      // This test is a best-effort check — it may still pass if no GC happened.
+      check.check() // must not throw regardless of result
+   }
+})

--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheckTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheckTest.kt
@@ -1,0 +1,31 @@
+package com.sksamuel.cohort.system
+
+import com.sksamuel.cohort.HealthStatus
+import com.sun.management.UnixOperatingSystemMXBean
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.lang.management.ManagementFactory
+
+class MaxFileDescriptorsHealthCheckTest : FunSpec({
+
+   val bean = ManagementFactory.getOperatingSystemMXBean() as UnixOperatingSystemMXBean
+
+   test("returns healthy when system max fd meets required threshold") {
+      MaxFileDescriptorsHealthCheck(1).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when required exceeds system max") {
+      MaxFileDescriptorsHealthCheck(Int.MAX_VALUE).check().status shouldBe HealthStatus.Unhealthy
+   }
+
+   test("returns healthy when required exactly equals system max") {
+      // verifies >= semantics: equal-to-required is healthy
+      val actual = bean.maxFileDescriptorCount.toInt()
+      MaxFileDescriptorsHealthCheck(actual).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when required is one above system max") {
+      val actual = bean.maxFileDescriptorCount.toInt()
+      MaxFileDescriptorsHealthCheck(actual + 1).check().status shouldBe HealthStatus.Unhealthy
+   }
+})

--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/system/OpenFileDescriptorsHealthCheckTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/system/OpenFileDescriptorsHealthCheckTest.kt
@@ -1,0 +1,32 @@
+package com.sksamuel.cohort.system
+
+import com.sksamuel.cohort.HealthStatus
+import com.sun.management.UnixOperatingSystemMXBean
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.lang.management.ManagementFactory
+
+class OpenFileDescriptorsHealthCheckTest : FunSpec({
+
+   val bean = ManagementFactory.getOperatingSystemMXBean() as UnixOperatingSystemMXBean
+
+   test("returns healthy when open count is below threshold") {
+      OpenFileDescriptorsHealthCheck(Int.MAX_VALUE).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when threshold is zero") {
+      // open fd count is always > 0 while tests run
+      OpenFileDescriptorsHealthCheck(0).check().status shouldBe HealthStatus.Unhealthy
+   }
+
+   test("returns healthy when open count exactly equals threshold") {
+      // verifies <= semantics: equal-to-threshold is healthy, not unhealthy
+      val actual = bean.openFileDescriptorCount.toInt()
+      OpenFileDescriptorsHealthCheck(actual).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when threshold is one below current open count") {
+      val actual = bean.openFileDescriptorCount.toInt()
+      OpenFileDescriptorsHealthCheck(actual - 1).check().status shouldBe HealthStatus.Unhealthy
+   }
+})


### PR DESCRIPTION
## Summary

- **`OpenFileDescriptorsHealthCheck`**: off-by-one error — condition used strict `<` instead of `<=`, so an open fd count exactly equal to the configured threshold was incorrectly reported unhealthy. Both the KDoc and the message string specified `<=` semantics.

- **`MaxFileDescriptorsHealthCheck`**: inverted condition — `files < requiredMaxDescriptors` returned healthy, meaning a system with *fewer* file descriptors than required was healthy. Fixed to `files >= requiredMaxDescriptors`. KDoc updated to match. (PR #135 renamed the variable but did not change the condition.)

- **`GarbageCollectionTimeCheck`**: two mutable fields (`lastTime`, `lastMark`) lacked `@Volatile`, risking stale reads when `check()` is called from different threads by the health check scheduler. Also fixes a `divide-by-zero` crash: when two consecutive calls complete within 1ms, `inWholeMilliseconds` truncates to `0`, making `timeDiff / 0.0 = NaN`, and `NaN.roundToInt()` throws `IllegalArgumentException`. Fixed by treating an elapsed time of zero the same as the first-call case (return healthy, no percentage computed).

- **`DatabaseHealthCheck`**: `Statement` returned by `createStatement()` was never closed. With connection pools the underlying connection is returned to the pool rather than closed, so unclosed statements leak until GC. Fixed by wrapping with `.use {}`.

## Test plan

- [ ] `OpenFileDescriptorsHealthCheck(actualCount)` returns Healthy (boundary = equal)
- [ ] `OpenFileDescriptorsHealthCheck(actualCount - 1)` returns Unhealthy
- [ ] `MaxFileDescriptorsHealthCheck(actualMax)` returns Healthy (boundary = equal)
- [ ] `MaxFileDescriptorsHealthCheck(Int.MAX_VALUE)` returns Unhealthy
- [ ] `GarbageCollectionTimeCheck` first invocation returns Healthy (elapsed is null)
- [ ] `GarbageCollectionTimeCheck` two back-to-back calls do not throw (elapsed can be 0)
- [ ] `DatabaseHealthCheck` with H2 returns Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)