### PR TITLE
Fix off-by-one in OpenFileDescriptorsHealthCheck

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/OpenFileDescriptorsHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/OpenFileDescriptorsHealthCheck.kt
@@ -18,7 +18,7 @@ class OpenFileDescriptorsHealthCheck(private val maxOpenFileDescriptors: Int) : 
 
   override suspend fun check(): HealthCheckResult {
     val open = bean.openFileDescriptorCount
-    return if (open < maxOpenFileDescriptors) {
+    return if (open <= maxOpenFileDescriptors) {
       HealthCheckResult.healthy("Open file descriptor count within threshold [$open <= $maxOpenFileDescriptors]")
     } else {
       HealthCheckResult.unhealthy("Open file descriptors count above threshold [$open > $maxOpenFileDescriptors]", null)

--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/system/OpenFileDescriptorsHealthCheckTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/system/OpenFileDescriptorsHealthCheckTest.kt
@@ -1,0 +1,32 @@
+package com.sksamuel.cohort.system
+
+import com.sksamuel.cohort.HealthStatus
+import com.sun.management.UnixOperatingSystemMXBean
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.lang.management.ManagementFactory
+
+class OpenFileDescriptorsHealthCheckTest : FunSpec({
+
+   val bean = ManagementFactory.getOperatingSystemMXBean() as UnixOperatingSystemMXBean
+
+   test("returns healthy when open count is below threshold") {
+      OpenFileDescriptorsHealthCheck(Int.MAX_VALUE).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when threshold is zero") {
+      // open fd count is always > 0 while tests run
+      OpenFileDescriptorsHealthCheck(0).check().status shouldBe HealthStatus.Unhealthy
+   }
+
+   test("returns healthy when open count exactly equals threshold") {
+      // verifies <= semantics: equal-to-threshold is healthy, not unhealthy
+      val actual = bean.openFileDescriptorCount.toInt()
+      OpenFileDescriptorsHealthCheck(actual).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when threshold is one below current open count") {
+      val actual = bean.openFileDescriptorCount.toInt()
+      OpenFileDescriptorsHealthCheck(actual - 1).check().status shouldBe HealthStatus.Unhealthy
+   }
+})


### PR DESCRIPTION
## Summary

`OpenFileDescriptorsHealthCheck` used strict `<` instead of `<=` when comparing the current open descriptor count against the configured threshold. A count exactly equal to the threshold was therefore incorrectly returned as unhealthy.

Both the KDoc ("healthy if the count <= [maxOpenFileDescriptors]") and the diagnostic message (`[$open <= $maxOpenFileDescriptors]`) specified inclusive semantics; the implementation did not match.

**Before:**
```kotlin
return if (open < maxOpenFileDescriptors) {
```
**After:**
```kotlin
return if (open <= maxOpenFileDescriptors) {
```

## Test plan

- [ ] `Open count == threshold` → Healthy (boundary case, verifies the fix)
- [ ] `Open count < threshold (Int.MAX_VALUE)` → Healthy
- [ ] `Threshold == 0` → Unhealthy (always has at least one fd open)
- [ ] `Threshold == actual - 1` → Unhealthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)