### PR TITLE
Fix inverted condition in MaxFileDescriptorsHealthCheck

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheck.kt
@@ -8,7 +8,7 @@ import java.lang.management.ManagementFactory
 /**
  * A Cohort [HealthCheck] for the number of max file descriptors.
  *
- * The check is considered healthy if the max count is <= [requiredMaxDescriptors].
+ * The check is considered healthy if the max count is >= [requiredMaxDescriptors].
  */
 class MaxFileDescriptorsHealthCheck(private val requiredMaxDescriptors: Int) : HealthCheck {
 
@@ -19,7 +19,7 @@ class MaxFileDescriptorsHealthCheck(private val requiredMaxDescriptors: Int) : H
   override suspend fun check(): HealthCheckResult {
     val files = bean.maxFileDescriptorCount
     val msg = "Max file descriptors $files [required at least $requiredMaxDescriptors]"
-    return if (files < requiredMaxDescriptors) {
+    return if (files >= requiredMaxDescriptors) {
       HealthCheckResult.healthy(msg)
     } else {
       HealthCheckResult.unhealthy(msg, null)

--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheckTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheckTest.kt
@@ -1,0 +1,31 @@
+package com.sksamuel.cohort.system
+
+import com.sksamuel.cohort.HealthStatus
+import com.sun.management.UnixOperatingSystemMXBean
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.lang.management.ManagementFactory
+
+class MaxFileDescriptorsHealthCheckTest : FunSpec({
+
+   val bean = ManagementFactory.getOperatingSystemMXBean() as UnixOperatingSystemMXBean
+
+   test("returns healthy when system max fd meets required threshold") {
+      MaxFileDescriptorsHealthCheck(1).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when required exceeds system max") {
+      MaxFileDescriptorsHealthCheck(Int.MAX_VALUE).check().status shouldBe HealthStatus.Unhealthy
+   }
+
+   test("returns healthy when required exactly equals system max") {
+      // verifies >= semantics: equal-to-required is healthy
+      val actual = bean.maxFileDescriptorCount.toInt()
+      MaxFileDescriptorsHealthCheck(actual).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when required is one above system max") {
+      val actual = bean.maxFileDescriptorCount.toInt()
+      MaxFileDescriptorsHealthCheck(actual + 1).check().status shouldBe HealthStatus.Unhealthy
+   }
+})


### PR DESCRIPTION
## Summary

`MaxFileDescriptorsHealthCheck` had an inverted condition: `files < requiredMaxDescriptors` returned **healthy**, meaning a system whose fd limit was *lower* than the configured requirement was reported as healthy — the opposite of the intent.

The diagnostic message `"Max file descriptors $files [required at least $requiredMaxDescriptors]"` makes the correct semantics clear: the check should pass only when the system limit is at least `requiredMaxDescriptors`.

PR #135 renamed the variable (`max` → `files`) but the condition itself was left unchanged.

**Before:**
```kotlin
return if (files < requiredMaxDescriptors) {
    HealthCheckResult.healthy(msg)
```
**After:**
```kotlin
return if (files >= requiredMaxDescriptors) {
    HealthCheckResult.healthy(msg)
```
KDoc also updated from `<=` to `>=`.

## Test plan

- [ ] `Required == 1` → Healthy (any real system has at least 1 fd)
- [ ] `Required == Int.MAX_VALUE` → Unhealthy (no system reaches that limit)
- [ ] `Required == actualMax` → Healthy (boundary: equal is healthy)
- [ ] `Required == actualMax + 1` → Unhealthy (one above actual is not met)

🤖 Generated with [Claude Code](https://claude.com/claude-code)