### PR TITLE
Fix @Volatile and divide-by-zero in GarbageCollectionTimeCheck

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/GarbageCollectionTimeCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/GarbageCollectionTimeCheck.kt
@@ -18,9 +18,9 @@ import kotlin.time.TimeSource
 class GarbageCollectionTimeCheck(private val maxGcTime: Int) : HealthCheck {
 
   private val beans = ManagementFactory.getGarbageCollectorMXBeans()
-  private var lastTime = 0L
+  @Volatile private var lastTime = 0L
   private val source = TimeSource.Monotonic
-  private var lastMark: TimeMark? = null
+  @Volatile private var lastMark: TimeMark? = null
 
   override val name: String = "garbage_collection_time"
 
@@ -34,7 +34,7 @@ class GarbageCollectionTimeCheck(private val maxGcTime: Int) : HealthCheck {
     val elapsed = lastMark?.elapsedNow()?.inWholeMilliseconds
     lastMark = source.markNow()
 
-    return if (elapsed == null) {
+    return if (elapsed == null || elapsed == 0L) {
       HealthCheckResult.healthy("GC Collection time was 0%")
     } else {
       val pc = (timeDiff / elapsed.toDouble()).roundToInt()

--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/memory/GarbageCollectionTimeCheckTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/memory/GarbageCollectionTimeCheckTest.kt
@@ -1,0 +1,29 @@
+package com.sksamuel.cohort.memory
+
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+@OptIn(kotlin.time.ExperimentalTime::class)
+class GarbageCollectionTimeCheckTest : FunSpec({
+
+   test("returns healthy on first invocation when elapsed time is unknown") {
+      GarbageCollectionTimeCheck(0).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns healthy on second invocation when GC time is well within threshold") {
+      // Two back-to-back calls can complete within 1ms; elapsed truncates to 0L.
+      // Previously this caused NaN.roundToInt() to throw — the fix guards elapsed == 0L.
+      val check = GarbageCollectionTimeCheck(100) // 100% threshold
+      check.check() // establish baseline
+      check.check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when GC time threshold is zero and GC has run") {
+      val check = GarbageCollectionTimeCheck(0)
+      check.check() // establish baseline
+      System.gc()
+      // best-effort: must not throw regardless of result
+      check.check()
+   }
+})


### PR DESCRIPTION
## Summary

Two bugs in `GarbageCollectionTimeCheck`:

**1. Missing `@Volatile` on mutable state**

`lastTime` and `lastMark` are written and read on every `check()` call. The health check scheduler can invoke `check()` from different threads, so without `@Volatile` a thread may see stale values. Both fields annotated.

**2. Divide-by-zero crash when calls are rapid**

`elapsed` is computed with `inWholeMilliseconds`, which truncates sub-millisecond durations to `0L`. When two consecutive `check()` calls complete within 1ms:

```
timeDiff / elapsed.toDouble()  →  x / 0.0  →  NaN  (or Infinity)
NaN.roundToInt()               →  IllegalArgumentException: Cannot round NaN value.
```

Fixed by treating `elapsed == 0L` identically to the first-call case (`elapsed == null`): return healthy with no percentage computed.

## Test plan

- [ ] First invocation returns Healthy (no baseline yet)
- [ ] Two back-to-back calls do not throw (covers the `elapsed == 0L` path)
- [ ] Call after `System.gc()` with 0% threshold must not throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)