### PR TITLE
Fix Statement resource leak in DatabaseHealthCheck

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/db/DatabaseHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/db/DatabaseHealthCheck.kt
@@ -18,7 +18,7 @@ class DatabaseHealthCheck(
 ) : HealthCheck {
 
    override suspend fun check(): HealthCheckResult = ds.connection.use { conn ->
-      conn.createStatement().executeQuery(query)
+      conn.createStatement().use { it.executeQuery(query) }
       HealthCheckResult.healthy("Connected to database successfully")
    }
 }

--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/db/DatabaseHealthCheckTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/db/DatabaseHealthCheckTest.kt
@@ -1,0 +1,19 @@
+package com.sksamuel.cohort.db
+
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+@Suppress("DEPRECATION")
+class DatabaseHealthCheckTest : FunSpec({
+
+   test("returns healthy when default SELECT 1 query succeeds") {
+      DatabaseHealthCheck(createHikariDS()).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns healthy when a custom query succeeds") {
+      val ds = createHikariDS()
+      ds.connection.use { it.createStatement().executeUpdate("CREATE TABLE test_db_health (id int)") }
+      DatabaseHealthCheck(ds, query = "SELECT * FROM test_db_health").check().status shouldBe HealthStatus.Healthy
+   }
+})


### PR DESCRIPTION
## Summary

`DatabaseHealthCheck.check()` called `conn.createStatement().executeQuery(query)` but never closed the resulting `Statement` or `ResultSet`. With a connection pool the underlying `Connection` is returned to the pool rather than closed, so neither resource is reclaimed promptly — they accumulate until GC eventually finalises the statement.

Fixed by wrapping the `Statement` in `.use {}`, which closes it (and its associated `ResultSet`) when the block exits.

**Before:**
```kotlin
override suspend fun check(): HealthCheckResult = ds.connection.use { conn ->
    conn.createStatement().executeQuery(query)
    HealthCheckResult.healthy("Connected to database successfully")
}
```
**After:**
```kotlin
override suspend fun check(): HealthCheckResult = ds.connection.use { conn ->
    conn.createStatement().use { it.executeQuery(query) }
    HealthCheckResult.healthy("Connected to database successfully")
}
```

## Test plan

- [ ] Default `SELECT 1` against H2 in-memory database returns Healthy
- [ ] Custom query against a table created in H2 returns Healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)