### PR TITLE
Fix inverted condition in KafkaConsumerTimeBetweenPollHealthCheck

### DIFF
--- a/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaConsumerTimeBetweenPollHealthCheck.kt
+++ b/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaConsumerTimeBetweenPollHealthCheck.kt
@@ -6,23 +6,23 @@ import org.apache.kafka.clients.consumer.Consumer
 import kotlin.math.roundToLong
 
 /**
- * A Cohort [HealthCheck] that checks that the average time between polls is above a given minimum.
+ * A Cohort [HealthCheck] that checks that the average time between polls does not exceed a given maximum.
  * This metric is measured in milliseconds.
  *
  * This metric does not begin to return unhealthy until the time is above zero. A time of zero,
- * which means no records were consumed, returns healthy. This allows consumers to take time
+ * which means the consumer has not yet polled, returns healthy. This allows consumers to take time
  * to subscribe and begin consuming.
  *
  * This check can be useful to detect stalled consumers.
  */
 class KafkaConsumerTimeBetweenPollHealthCheck(
    consumer: Consumer<*, *>,
-   private val minThreshold: Long,
+   private val maxThreshold: Long,
    override val name: String = "kafka_consumer_time_between_poll_avg",
 ) : AbstractKafkaConsumerMetricHealthCheck(consumer) {
 
    init {
-      require(minThreshold > 0) { "The minimum threshold is > 0" }
+      require(maxThreshold > 0) { "The maximum threshold must be > 0" }
    }
 
    private val metricName = "time-between-poll-avg"
@@ -30,10 +30,10 @@ class KafkaConsumerTimeBetweenPollHealthCheck(
    override suspend fun check(): HealthCheckResult {
       return metric(metricName).map { metric ->
          val rate = runCatching { metric.metricValue().toString().toDouble().roundToLong() }.getOrElse { 0L }
-         val msg = "Kafka consumer time-between-poll-avg $rate [minThreshold $minThreshold]"
+         val msg = "Kafka consumer time-between-poll-avg ${rate}ms [maxThreshold ${maxThreshold}ms]"
          return when {
             rate == 0L -> HealthCheckResult.healthy(msg)
-            rate < minThreshold -> HealthCheckResult.unhealthy(msg, null)
+            rate > maxThreshold -> HealthCheckResult.unhealthy(msg, null)
             else -> HealthCheckResult.healthy(msg)
          }
       }.fold({ it }, { it })

--- a/cohort-kafka/src/test/kotlin/com/sksamuel/cohort/kafka/KafkaConsumerTimeBetweenPollHealthCheckTest.kt
+++ b/cohort-kafka/src/test/kotlin/com/sksamuel/cohort/kafka/KafkaConsumerTimeBetweenPollHealthCheckTest.kt
@@ -1,70 +1,45 @@
-//package com.sksamuel.cohort.kafka
-//
-//import com.sksamuel.cohort.HealthStatus
-//import io.kotest.assertions.nondeterministic.continually
-//import io.kotest.assertions.nondeterministic.eventually
-//import io.kotest.assertions.withClue
-//import io.kotest.core.extensions.install
-//import io.kotest.core.spec.style.FunSpec
-//import io.kotest.extensions.testcontainers.kafka.KafkaContainerExtension
-//import io.kotest.extensions.testcontainers.kafka.admin
-//import io.kotest.extensions.testcontainers.kafka.consumer
-//import io.kotest.extensions.testcontainers.kafka.producer
-//import io.kotest.matchers.shouldBe
-//import kotlinx.coroutines.delay
-//import kotlinx.coroutines.isActive
-//import kotlinx.coroutines.launch
-//import org.apache.kafka.clients.admin.NewTopic
-//import org.apache.kafka.clients.producer.ProducerRecord
-//import org.apache.kafka.common.utils.Bytes
-//import org.testcontainers.containers.KafkaContainer
-//import org.testcontainers.utility.DockerImageName
-//import java.time.Duration
-//import kotlin.time.Duration.Companion.milliseconds
-//import kotlin.time.Duration.Companion.seconds
-//
-//class KafkaConsumerTimeBetweenPollHealthCheckTest : FunSpec({
-//
-//   val kafka = install(KafkaContainerExtension(KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka"))))
-//
-//   test("health check should pass while consumer has not yet consumed") {
-//
-//      kafka.admin().use { it.createTopics(listOf(NewTopic("mytopic1", 1, 1))).all().get() }
-//      val consumer = kafka.consumer()
-//      val healthcheck = KafkaConsumerTimeBetweenPollHealthCheck(consumer, 1)
-//      continually(5.seconds) {
-//         healthcheck.check().status shouldBe HealthStatus.Healthy
-//         delay(250.milliseconds)
-//      }
-//   }
-//
-//   test("health check should pass while rate is above threshold") {
-//
-//      kafka.admin().use { it.createTopics(listOf(NewTopic("mytopic2", 1, 1))).all().get() }
-//
-//      val producer = kafka.producer()
-//      val consumer = kafka.consumer()
-//      consumer.subscribe(listOf("mytopic2"))
-//
-//      val job = launch {
-//         while (isActive) {
-//            delay(10)
-//            producer.send(ProducerRecord("mytopic2", Bytes.wrap(byteArrayOf()), Bytes.wrap(byteArrayOf())))
-//         }
-//      }
-//
-//      val healthcheck = KafkaConsumerTimeBetweenPollHealthCheck(consumer, 200)
-//      eventually(5.seconds) {
-//         consumer.poll(Duration.ofMillis(100))
-//         val result = healthcheck.check()
-//         withClue(result) {
-//            result.status shouldBe HealthStatus.Healthy
-//         }
-//         delay(250.milliseconds)
-//      }
-//
-//      job.cancel()
-//      producer.close()
-//      consumer.close()
-//   }
-//})
+package com.sksamuel.cohort.kafka
+
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.apache.kafka.clients.consumer.Consumer
+import org.apache.kafka.common.Metric
+import org.apache.kafka.common.MetricName
+
+class KafkaConsumerTimeBetweenPollHealthCheckTest : FunSpec({
+
+   fun consumer(timeBetweenPollMs: Double): Consumer<*, *> {
+      val consumer = mockk<Consumer<*, *>>()
+      val metricName = MetricName("time-between-poll-avg", "consumer-fetch-manager-metrics", "", emptyMap())
+      val metric = mockk<Metric>()
+      every { metric.metricName() } returns metricName
+      every { metric.metricValue() } returns timeBetweenPollMs
+      every { consumer.metrics() } returns mapOf(metricName to metric)
+      return consumer
+   }
+
+   test("returns healthy when time is zero (consumer not yet polling)") {
+      KafkaConsumerTimeBetweenPollHealthCheck(consumer(0.0), maxThreshold = 5000L)
+         .check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns healthy when time between polls is well below threshold") {
+      // Polling every 100ms is well under the 5000ms stall threshold
+      KafkaConsumerTimeBetweenPollHealthCheck(consumer(100.0), maxThreshold = 5000L)
+         .check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when time between polls exceeds threshold") {
+      // 10 seconds between polls with a 5000ms threshold — consumer is stalled
+      KafkaConsumerTimeBetweenPollHealthCheck(consumer(10000.0), maxThreshold = 5000L)
+         .check().status shouldBe HealthStatus.Unhealthy
+   }
+
+   test("returns healthy when time between polls exactly equals threshold") {
+      KafkaConsumerTimeBetweenPollHealthCheck(consumer(5000.0), maxThreshold = 5000L)
+         .check().status shouldBe HealthStatus.Healthy
+   }
+})


### PR DESCRIPTION
## Summary

`time-between-poll-avg` measures the average number of milliseconds between consecutive `poll()` calls on a Kafka consumer. A **stalled** consumer stops calling `poll()`, so its interval grows large.

The previous condition:
```kotlin
rate < minThreshold -> HealthCheckResult.unhealthy(msg, null)
```
returned unhealthy when the consumer was polling *too frequently* — the exact opposite of stall detection. A healthy, active consumer polling every 100ms with a threshold of 5000ms would be reported unhealthy.

**Fix:** flip the comparison and rename the parameter to reflect the correct semantics:
```kotlin
rate > maxThreshold -> HealthCheckResult.unhealthy(msg, null)
```

For reference, `KafkaConsumerLastPollHealthCheck` — which serves the same "detect stalled consumers" purpose — correctly uses `>`:
```kotlin
return if (lastPollSecondsAgo > interval.inWholeSeconds)
    HealthCheckResult.unhealthy(msg, null)
```

The KDoc ("above a given minimum") and parameter name (`minThreshold`) are also updated to accurately describe the maximum-threshold semantics.

The previously all-commented-out test file is replaced with four active mockk-based tests.

## Test plan

- [ ] `rate == 0` → Healthy (startup grace — consumer has not polled yet)
- [ ] `rate = 100ms`, `maxThreshold = 5000ms` → Healthy (frequent polling)
- [ ] `rate = 10000ms`, `maxThreshold = 5000ms` → Unhealthy (stalled consumer)
- [ ] `rate == maxThreshold` → Healthy (boundary: equal is not exceeded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)