### PR TITLE
Fix temp heap dump file leak in getHeapDump

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/heap/Heapdump.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/heap/Heapdump.kt
@@ -13,7 +13,9 @@ fun getHeapDump(): Result<ByteArray> = runCatching {
   val mxBean = ManagementFactory.newPlatformMXBeanProxy(server, HOTSPOT_BEAN_NAME, HotSpotDiagnosticMXBean::class.java)
   val path = Paths.get("/tmp/heapdump" + System.currentTimeMillis() + ".hprof")
   mxBean.dumpHeap(path.toString(), true)
-  val dump = Files.readAllBytes(path)
-  path.deleteIfExists()
-  dump
+  try {
+    Files.readAllBytes(path)
+  } finally {
+    path.deleteIfExists()
+  }
 }


### PR DESCRIPTION
## Summary

`getHeapDump()` wrote the heap dump to a temp file in `/tmp`, read it with `Files.readAllBytes(path)`, then deleted the file. If `readAllBytes` throws (most likely `OutOfMemoryError` — reading a heap dump into memory is inherently risky), `deleteIfExists()` is never reached and the `.hprof` file remains on disk indefinitely.

**Before:**
```kotlin
mxBean.dumpHeap(path.toString(), true)
val dump = Files.readAllBytes(path)
path.deleteIfExists()   // skipped if readAllBytes throws
dump
```
**After:**
```kotlin
mxBean.dumpHeap(path.toString(), true)
try {
    Files.readAllBytes(path)
} finally {
    path.deleteIfExists()   // always runs
}
```

## Test plan

- [ ] Compiles cleanly
- [ ] Happy path: heap dump is written, read, and temp file removed (existing behaviour)
- [ ] Exception path: temp file is removed even when `readAllBytes` throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)