### PR TITLE
Remove dead registry.logUnhealthy statement in Vert.x health endpoint

### DIFF
--- a/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
+++ b/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
@@ -191,8 +191,6 @@ fun Router.cohort(cohort: CohortConfiguration) {
                )
             }
 
-            registry.logUnhealthy
-
             when (status.healthy) {
                true -> context.json(results)
                false -> context.response().setStatusCode(HttpResponseStatus.SERVICE_UNAVAILABLE.code()).end()


### PR DESCRIPTION
## Summary

In `vertx.kt`, the health check endpoint handler contained a bare expression:

```kotlin
registry.logUnhealthy
```

`logUnhealthy` is a plain `Boolean` property with no custom getter. Reading it and discarding the value is a complete no-op. It was most likely a leftover from a refactor — the original intent was probably `if (registry.logUnhealthy) { ... }`, but the body was dropped. The registry already handles unhealthy logging internally inside its `failure()` method, so no replacement logic is needed.

## Test plan

- [ ] Compiles cleanly — no behaviour change expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)