### PR TITLE
Fix missing JSON body in Vert.x health endpoint 503 responses

### DIFF
--- a/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
+++ b/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
@@ -193,10 +193,9 @@ fun Router.cohort(cohort: CohortConfiguration) {
 
             registry.logUnhealthy
 
-            when (status.healthy) {
-               true -> context.json(results)
-               false -> context.response().setStatusCode(HttpResponseStatus.SERVICE_UNAVAILABLE.code()).end()
-            }
+            val httpStatus = if (status.healthy) HttpResponseStatus.OK else HttpResponseStatus.SERVICE_UNAVAILABLE
+            context.response().setStatusCode(httpStatus.code())
+            context.json(results)
          }
    }
 }


### PR DESCRIPTION
## Summary

The Vert.x health check endpoint returned an empty response body when the service was unhealthy (HTTP 503). Operators and load balancers relying on the JSON payload to identify which checks had failed received no information.

**Before:**
```kotlin
when (status.healthy) {
    true  -> context.json(results)
    false -> context.response().setStatusCode(503).end()  // no body
}
```

**After:**
```kotlin
val httpStatus = if (status.healthy) HttpResponseStatus.OK else HttpResponseStatus.SERVICE_UNAVAILABLE
context.response().setStatusCode(httpStatus.code())
context.json(results)   // always sends the full check list
```

`RoutingContext.json(obj)` uses the status code already set on the response, so setting it before calling `json()` produces a 503 with the full JSON results body — matching the behaviour of the Ktor integration, which always returns JSON regardless of health status.

## Test plan

- [ ] Healthy service: GET `/healthcheck` returns 200 with JSON results body
- [ ] Unhealthy service: GET `/healthcheck` returns 503 **with** JSON results body showing which checks failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)