### PR TITLE
Fix percentage calculation in GarbageCollectionTimeCheck

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/GarbageCollectionTimeCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/GarbageCollectionTimeCheck.kt
@@ -37,7 +37,7 @@ class GarbageCollectionTimeCheck(private val maxGcTime: Int) : HealthCheck {
     return if (elapsed == null || elapsed == 0L) {
       HealthCheckResult.healthy("GC Collection time was 0%")
     } else {
-      val pc = (timeDiff / elapsed.toDouble()).roundToInt()
+      val pc = (timeDiff / elapsed.toDouble() * 100).roundToInt()
       val message = "GC Collection time was ${timeDiff}ms / $pc% [Max is $maxGcTime%]"
       if (pc <= maxGcTime) {
         HealthCheckResult.healthy(message)


### PR DESCRIPTION
## Summary
- `GarbageCollectionTimeCheck` divides `timeDiff` by `elapsed` and rounds — but never multiplies by 100, so the result was a fraction in 0..1 (rounded to 0 or 1) instead of a percentage in 0..100.
- The class doc and message both say the value is a percentage (`maxGcTime%`, "GC Collection time was ${pc}%"). A real 50% GC overhead was reported as "0%" and never tripped the threshold.

## Test plan
- [ ] Existing `GarbageCollectionTimeCheckTest` cases still pass (they don't assert specific percentages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)