### PR TITLE
Fix inverted condition in MaxFileDescriptorsHealthCheck

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheck.kt
@@ -8,7 +8,7 @@ import java.lang.management.ManagementFactory
 /**
  * A Cohort [HealthCheck] for the number of max file descriptors.
  *
- * The check is considered healthy if the max count is <= [requiredMaxDescriptors].
+ * The check is considered healthy if the system's max file descriptor limit is >= [requiredMaxDescriptors].
  */
 class MaxFileDescriptorsHealthCheck(private val requiredMaxDescriptors: Int) : HealthCheck {
 
@@ -19,7 +19,7 @@ class MaxFileDescriptorsHealthCheck(private val requiredMaxDescriptors: Int) : H
   override suspend fun check(): HealthCheckResult {
     val files = bean.maxFileDescriptorCount
     val msg = "Max file descriptors $files [required at least $requiredMaxDescriptors]"
-    return if (files < requiredMaxDescriptors) {
+    return if (files >= requiredMaxDescriptors) {
       HealthCheckResult.healthy(msg)
     } else {
       HealthCheckResult.unhealthy(msg, null)

--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheckTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheckTest.kt
@@ -1,0 +1,30 @@
+package com.sksamuel.cohort.system
+
+import com.sksamuel.cohort.HealthStatus
+import com.sun.management.UnixOperatingSystemMXBean
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.lang.management.ManagementFactory
+
+class MaxFileDescriptorsHealthCheckTest : FunSpec({
+
+   val bean = ManagementFactory.getOperatingSystemMXBean() as UnixOperatingSystemMXBean
+
+   test("returns healthy when system limit meets the required minimum") {
+      MaxFileDescriptorsHealthCheck(1).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when required minimum exceeds system limit") {
+      MaxFileDescriptorsHealthCheck(Int.MAX_VALUE).check().status shouldBe HealthStatus.Unhealthy
+   }
+
+   test("returns healthy when required minimum exactly equals system limit") {
+      val actual = bean.maxFileDescriptorCount.toInt()
+      MaxFileDescriptorsHealthCheck(actual).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when required minimum is one above system limit") {
+      val actual = bean.maxFileDescriptorCount.toInt()
+      MaxFileDescriptorsHealthCheck(actual + 1).check().status shouldBe HealthStatus.Unhealthy
+   }
+})


### PR DESCRIPTION
## Summary
- `MaxFileDescriptorsHealthCheck` reports the **opposite** of what it should: when the system's max fd limit is *less than* the configured requirement, the check returned healthy. The diagnostic message (`"required at least $requiredMaxDescriptors"`) and the typical use of this check (verifying the host meets a minimum) confirm the intent — flip the comparison to `>=`.
- Adds unit tests covering boundary cases: meets minimum, equals limit, exceeds limit by one, and `Int.MAX_VALUE`.

Previous attempts (#145, #139) were closed; the source still has the bug, so opening a fresh PR with tests included.

## Test plan
- [x] `MaxFileDescriptorsHealthCheckTest` — all four boundary cases pass locally via `./gradlew :cohort-api:test --tests MaxFileDescriptorsHealthCheckTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)