### PR TITLE
Fix copy-paste log messages in Vert.x cohort router

### DIFF
--- a/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
+++ b/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
@@ -129,7 +129,7 @@ fun Router.cohort(cohort: CohortConfiguration) {
 
    if (cohort.threadDump) {
       val endpoint = "${cohort.endpointPrefix}/threaddump"
-      logger.debug("Deploying operatingSystem endpoint at $endpoint")
+      logger.debug("Deploying threadDump endpoint at $endpoint")
       router.get(endpoint)
          .consumes("*")
          .produces("*")
@@ -143,7 +143,7 @@ fun Router.cohort(cohort: CohortConfiguration) {
 
    if (cohort.sysprops) {
       val endpoint = "${cohort.endpointPrefix}/sysprops"
-      logger.debug("Deploying operatingSystem endpoint at $endpoint")
+      logger.debug("Deploying sysprops endpoint at $endpoint")
       router.get(endpoint)
          .consumes("*")
          .produces("*")


### PR DESCRIPTION
## Summary
- Two debug log statements in `cohort-vertx/.../vertx.kt` claimed `"Deploying operatingSystem endpoint at $endpoint"` while actually wiring up the `threadDump` and `sysprops` handlers — a leftover from copying the `operatingSystem` block.
- Replace each message with one that names the actual endpoint.

## Test plan
- [x] `./gradlew :cohort-vertx:compileKotlin` succeeds
- [x] No behavioural change — log strings only

🤖 Generated with [Claude Code](https://claude.com/claude-code)