### PR TITLE
Fix RabbitQueueHealthCheckTest against RabbitMQ 4.0+

### DIFF
--- a/cohort-rabbit/src/test/kotlin/com/sksamuel/cohort/rabbit/RabbitQueueHealthCheckTest.kt
+++ b/cohort-rabbit/src/test/kotlin/com/sksamuel/cohort/rabbit/RabbitQueueHealthCheckTest.kt
@@ -22,10 +22,12 @@ class RabbitQueueHealthCheckTest : FunSpec({
    }
 
    beforeSpec {
-      // Create the queue used in the healthy tests
+      // Create the queue used in the healthy tests.
+      // Declared as durable because RabbitMQ 4.0+ rejects transient non-exclusive queues
+      // (feature `transient_nonexcl_queues` is deprecated).
       factory().newConnection().use { conn ->
          conn.createChannel().use { ch ->
-            ch.queueDeclare("test-queue", false, false, false, null)
+            ch.queueDeclare("test-queue", true, false, false, null)
          }
       }
    }


### PR DESCRIPTION
## Summary
The main branch CI started failing ([run 25015099490](https://github.com/sksamuel/cohort/actions/runs/25015099490/job/73260721705)) with no triggering commit:

```
RabbitQueueHealthCheckTest > Before Spec Error FAILED
    com.rabbitmq.client.ShutdownSignalException: connection error;
    reply-code=541, reply-text=INTERNAL_ERROR -
    Feature `transient_nonexcl_queues` is deprecated.
```

`RabbitQueueHealthCheckTest`'s `beforeSpec` declares `test-queue` with `durable=false, exclusive=false, autoDelete=false` — a *transient non-exclusive* queue. RabbitMQ 4.0 deprecated this configuration and now refuses the declaration. The test container pulls `rabbitmq:latest`, so the failure surfaced when the Docker Hub `latest` tag advanced to 4.x — no repo commit needed.

Production code uses `queueDeclarePassive` (just checks for existence) and is unaffected. Only the test setup needs updating.

Declared the queue as **durable** — recommended pattern and works against both 3.x and 4.x brokers.

## Test plan
- [x] `./gradlew :cohort-rabbit:test --tests RabbitQueueHealthCheckTest` — all 3 tests pass locally against the live container

🤖 Generated with [Claude Code](https://claude.com/claude-code)