### PR TITLE
Fix inverted condition in MaxFileDescriptorsHealthCheck

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheck.kt
@@ -8,7 +8,7 @@ import java.lang.management.ManagementFactory
 /**
  * A Cohort [HealthCheck] for the number of max file descriptors.
  *
- * The check is considered healthy if the max count is <= [requiredMaxDescriptors].
+ * The check is considered healthy if the system's max file descriptor limit is >= [requiredMaxDescriptors].
  */
 class MaxFileDescriptorsHealthCheck(private val requiredMaxDescriptors: Int) : HealthCheck {
 
@@ -19,7 +19,7 @@ class MaxFileDescriptorsHealthCheck(private val requiredMaxDescriptors: Int) : H
   override suspend fun check(): HealthCheckResult {
     val files = bean.maxFileDescriptorCount
     val msg = "Max file descriptors $files [required at least $requiredMaxDescriptors]"
-    return if (files < requiredMaxDescriptors) {
+    return if (files >= requiredMaxDescriptors) {
       HealthCheckResult.healthy(msg)
     } else {
       HealthCheckResult.unhealthy(msg, null)

--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheckTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheckTest.kt
@@ -1,0 +1,30 @@
+package com.sksamuel.cohort.system
+
+import com.sksamuel.cohort.HealthStatus
+import com.sun.management.UnixOperatingSystemMXBean
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.lang.management.ManagementFactory
+
+class MaxFileDescriptorsHealthCheckTest : FunSpec({
+
+   val bean = ManagementFactory.getOperatingSystemMXBean() as UnixOperatingSystemMXBean
+
+   test("returns healthy when system limit meets the required minimum") {
+      MaxFileDescriptorsHealthCheck(1).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when required minimum exceeds system limit") {
+      MaxFileDescriptorsHealthCheck(Int.MAX_VALUE).check().status shouldBe HealthStatus.Unhealthy
+   }
+
+   test("returns healthy when required minimum exactly equals system limit") {
+      val actual = bean.maxFileDescriptorCount.toInt()
+      MaxFileDescriptorsHealthCheck(actual).check().status shouldBe HealthStatus.Healthy
+   }
+
+   test("returns unhealthy when required minimum is one above system limit") {
+      val actual = bean.maxFileDescriptorCount.toInt()
+      MaxFileDescriptorsHealthCheck(actual + 1).check().status shouldBe HealthStatus.Unhealthy
+   }
+})


### PR DESCRIPTION
## Summary
- `MaxFileDescriptorsHealthCheck.check()` had `files < requiredMaxDescriptors` returning **healthy** — the opposite of the intended semantics. The README ("Checks that the number of max file descriptors is at least a required level.") and the diagnostic message (`"required at least \$requiredMaxDescriptors"`) both describe the parameter as a **minimum**, so a host whose fd limit fell *below* the requirement was incorrectly reported as healthy.
- Flip the comparison to `>=` so the check is healthy when the system's max fd limit meets or exceeds the configured minimum.
- Update the class kdoc to match.

## Test plan
- [x] New `MaxFileDescriptorsHealthCheckTest` covers four boundary cases (meets minimum, equals limit, exceeds limit by one, `Int.MAX_VALUE`). Verified locally with `./gradlew :cohort-api:test --tests MaxFileDescriptorsHealthCheckTest` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)