### PR TITLE
Fix Vert.x heap dump endpoint serving binary as base64-encoded JSON

### DIFF
--- a/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
+++ b/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
@@ -11,6 +11,7 @@ import com.sksamuel.cohort.system.getSysProps
 import com.sksamuel.cohort.threads.getThreadDump
 import com.sksamuel.tabby.results.sequence
 import io.netty.handler.codec.http.HttpResponseStatus
+import io.vertx.core.buffer.Buffer
 import io.vertx.ext.web.Router
 import org.slf4j.LoggerFactory
 import java.time.ZoneOffset
@@ -30,7 +31,11 @@ fun Router.cohort(cohort: CohortConfiguration) {
          .produces("*")
          .handler { context ->
             getHeapDump().fold(
-               { context.json(it) },
+               {
+                  context.response()
+                     .putHeader("Content-Type", "application/octet-stream")
+                     .end(Buffer.buffer(it))
+               },
                { context.response().setStatusCode(500).end() },
             )
          }


### PR DESCRIPTION
## Summary
- The Vert.x heap dump handler in \`cohort-vertx/.../vertx.kt\` (line 33) called \`context.json(it)\` on the raw \`.hprof\` byte array. Vert.x's JSON codec runs the array through Jackson, which base64-encodes a \`ByteArray\` into a JSON string — so clients of \`/cohort/heapdump\` got back a quoted base64 blob with \`Content-Type: application/json\` instead of the binary heap dump. The Ktor sibling already serves the \`ByteArray\` directly via \`call.respond\`.
- Set \`Content-Type: application/octet-stream\` and write the bytes via \`Buffer.buffer(it)\` so the response is a usable \`.hprof\` file.

## Test plan
- [x] \`./gradlew :cohort-vertx:compileKotlin\` succeeds.
- The module has no test source set, so verification is limited to compilation; the change is a small, mechanical fix matching the Ktor implementation's contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)