### PR TITLE
Fix Vert.x logging endpoint double-encoding the JSON body

### DIFF
--- a/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
+++ b/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
@@ -83,7 +83,7 @@ fun Router.cohort(cohort: CohortConfiguration) {
             runCatching {
                val levels = manager.levels()
                val loggers = manager.loggers()
-               LogInfo(levels, loggers).toJson()
+               LogInfo(levels, loggers)
             }.fold(
                { context.json(it) },
                { context.response().setStatusCode(500).end() },


### PR DESCRIPTION
## Summary
- The \`/cohort/logging\` GET handler in \`cohort-vertx/.../vertx.kt\` called \`LogInfo(...).toJson()\` (which returns a JSON \`String\`) and then passed that string to \`context.json(it)\`. \`context.json\` delegates to Jackson's \`writeValueAsBytes\`, which encodes a \`String\` as a JSON string literal — so the response body was the *already-encoded* JSON string encoded a second time, e.g. \`"\\"{\\\\\\"levels\\\\\\":[...]}\\""\` instead of \`{"levels":[...]}\`.
- Pass the \`LogInfo\` data class directly to \`context.json\` so Vert.x's Jackson codec serializes it once.

## Test plan
- [x] \`./gradlew :cohort-vertx:compileKotlin\` succeeds.
- The module has no test source set, so verification is limited to compilation; the change is a one-line fix matching the pattern already used by every other GET handler in this file (memory, datasources, jvm, gc, sysprops, os, healthchecks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)