### PR TITLE
Dispatch PulsarHealthCheck blocking call onto Dispatchers.IO

### DIFF
--- a/cohort-pulsar/src/main/kotlin/com/sksamuel/cohort/pulsar/PulsarHealthCheck.kt
+++ b/cohort-pulsar/src/main/kotlin/com/sksamuel/cohort/pulsar/PulsarHealthCheck.kt
@@ -2,6 +2,8 @@ package com.sksamuel.cohort.pulsar
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
 import org.apache.pulsar.client.admin.PulsarAdmin
 
 class PulsarHealthCheck(
@@ -19,7 +21,9 @@ class PulsarHealthCheck(
 
    override suspend fun check(): HealthCheckResult {
       return runCatching {
-         client.clusters().getClusters()
+         runInterruptible(Dispatchers.IO) {
+            client.clusters().getClusters()
+         }
          HealthCheckResult.healthy("Connected to Pulsar")
       }.getOrElse { HealthCheckResult.unhealthy("Could not connect to Pulsar", it) }
    }


### PR DESCRIPTION
## Summary
- \`PulsarAdmin.clusters().getClusters()\` is a synchronous, blocking HTTP call. \`PulsarHealthCheck.check()\` invoked it directly from the \`suspend\` function — which means \`HealthCheckRegistry.checkTimeout\` (\`withTimeout\`, cooperative cancellation) cannot interrupt it: the timeout fires only at suspension points. A slow or unreachable Pulsar broker hangs the check past its configured timeout, can starve the registry's dispatcher, and produces a misleading "the timeout setting works" assumption.
- Wrap the call in \`runInterruptible(Dispatchers.IO)\`, matching the established pattern in \`RabbitConnectionHealthCheck\`, \`S3ReadBucketHealthCheck\` / \`S3WriteBucketHealthCheck\`, \`SNSHealthCheck\`, \`SQSQueueHealthCheck\`, and \`MongoConnectionHealthCheck\`'s sync-client path.

## Test plan
- [x] \`./gradlew :cohort-pulsar:compileKotlin\` succeeds.
- The module has no test source set; the change matches the cancellable-blocking pattern used elsewhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)