### PR TITLE
Dispatch LdapHealthCheck blocking JNDI bind onto Dispatchers.IO

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/ldap/LdapHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/ldap/LdapHealthCheck.kt
@@ -2,6 +2,8 @@ package com.sksamuel.cohort.ldap
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
 import java.util.Hashtable
 import javax.naming.directory.InitialDirContext
 
@@ -25,8 +27,10 @@ class LdapHealthCheck(
       val table = Hashtable<String, String>()
       environment.forEach { (key, value) -> table[key] = value }
 
-      val context = InitialDirContext(table)
-      context.close()
+      runInterruptible(Dispatchers.IO) {
+         val context = InitialDirContext(table)
+         context.close()
+      }
 
       HealthCheckResult.healthy("LDAP connection success")
    }.getOrElse { HealthCheckResult.unhealthy("LDAP Failure", it) }


### PR DESCRIPTION
## Summary
- Constructing \`InitialDirContext\` performs a blocking JNDI/LDAP bind (network connect + auth). \`LdapHealthCheck.check()\` called the constructor directly from a \`suspend\` function, so \`HealthCheckRegistry.checkTimeout\` (\`withTimeout\`, cooperative cancellation) cannot interrupt it — cancellation only fires at suspension points. An unreachable or slow LDAP server hangs the check past its configured timeout.
- Wrap the \`InitialDirContext\` construction and \`close()\` in \`runInterruptible(Dispatchers.IO)\`, matching the established pattern used by \`RabbitConnectionHealthCheck\`, the AWS S3/SNS/SQS checks, and \`MongoConnectionHealthCheck\`'s sync-client path.

## Test plan
- [x] \`./gradlew :cohort-api:compileKotlin\` succeeds.
- LDAP doesn't have a unit test in this repo; the change matches the cancellable-blocking pattern used elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)