### PR TITLE
Dispatch DatabaseConnectionHealthCheck blocking JDBC onto Dispatchers.IO

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/db/DatabaseConnectionHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/db/DatabaseConnectionHealthCheck.kt
@@ -2,6 +2,8 @@ package com.sksamuel.cohort.db
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
 import javax.sql.DataSource
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -22,13 +24,15 @@ class DatabaseConnectionHealthCheck(
 ) : HealthCheck {
 
    override suspend fun check(): HealthCheckResult = runCatching {
-      ds.connection.use { conn ->
-         if (!conn.isValid(timeout.inWholeSeconds.toInt())) {
-            return@use HealthCheckResult.unhealthy("Connection is invalid")
+      runInterruptible(Dispatchers.IO) {
+         ds.connection.use { conn ->
+            if (!conn.isValid(timeout.inWholeSeconds.toInt())) {
+               return@use HealthCheckResult.unhealthy("Connection is invalid")
+            }
+            if (query != null)
+               conn.createStatement().use { it.execute(query) }
+            HealthCheckResult.healthy("Connected to database successfully")
          }
-         if (query != null)
-            conn.createStatement().use { it.execute(query) }
-         HealthCheckResult.healthy("Connected to database successfully")
       }
    }.getOrElse { HealthCheckResult.unhealthy("Unable to connect to the database", it) }
 }


### PR DESCRIPTION
## Summary
- \`DataSource.getConnection()\`, \`Connection.isValid(timeout)\`, and \`Statement.execute(query)\` are all blocking JDBC calls. \`DatabaseConnectionHealthCheck.check()\` invoked them directly from a \`suspend\` function — \`HealthCheckRegistry.checkTimeout\` (\`withTimeout\`, cooperative cancellation) cannot interrupt blocking JDBC because cancellation only fires at suspension points. A slow database, a saturated pool, or a network hang keeps the check running past its configured timeout and ties up a thread on the registry's dispatcher.
- Wrap the connection-acquire-validate-execute block in \`runInterruptible(Dispatchers.IO)\`, matching the pattern already used by \`RabbitConnectionHealthCheck\`, the AWS S3 / SNS / SQS checks, and \`MongoConnectionHealthCheck\`'s sync-client path.

## Test plan
- [x] \`./gradlew :cohort-api:test --tests DatabaseConnectionHealthCheckTest\` — all four existing tests pass (healthy/null query, healthy/valid query, unhealthy/invalid query, unhealthy/invalid connection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)