### PR TITLE
Honor logUnhealthy in HealthCheckRegistry.failure()

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
@@ -219,7 +219,9 @@ class HealthCheckRegistry(
       val previous = statuses[name]
       val failures = if (previous == null) 1 else previous.consecutiveFailures + 1
 
-      logger.warn("HealthCheck $name reported $failures failures $result")
+      if (logUnhealthy) {
+         logger.warn("HealthCheck $name reported $failures failures $result")
+      }
 
       statuses[name] = HealthCheckStatus(
          consecutiveSuccesses = 0, // reset to 0 when we have a failure


### PR DESCRIPTION
## Summary
- \`HealthCheckRegistry.logUnhealthy\` is a public \`var\` (line 41) — the deprecated constructor's own deprecation message tells users to set it inside the configuration block — but nothing in the codebase reads it. \`failure()\` (line 222) unconditionally calls \`logger.warn(...)\` for every unhealthy result. A user who sets \`logUnhealthy = false\` expecting to silence the per-failure warnings sees no change in behavior.
- Gate the WARN log on the flag so the public field actually does what its name says. Default remains \`true\`, so log output is unchanged for users who don't opt out.

## Test plan
- [x] \`./gradlew :cohort-api:test --tests HealthCheckRegistryTest\` — all three existing tests pass (duplicate-name, slow-blocking, timeout).
- The slow-blocking test exercises the failure path (one of the three checks fails) with default \`logUnhealthy = true\`, so the log line is still emitted in CI as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)