### PR TITLE
Dispatch deprecated DatabaseHealthCheck blocking JDBC onto Dispatchers.IO

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/db/DatabaseHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/db/DatabaseHealthCheck.kt
@@ -2,6 +2,8 @@ package com.sksamuel.cohort.db
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
 import javax.sql.DataSource
 
 /**
@@ -17,8 +19,10 @@ class DatabaseHealthCheck(
    override val name: String = "database",
 ) : HealthCheck {
 
-   override suspend fun check(): HealthCheckResult = ds.connection.use { conn ->
-      conn.createStatement().use { it.executeQuery(query) }
-      HealthCheckResult.healthy("Connected to database successfully")
+   override suspend fun check(): HealthCheckResult = runInterruptible(Dispatchers.IO) {
+      ds.connection.use { conn ->
+         conn.createStatement().use { it.executeQuery(query) }
+         HealthCheckResult.healthy("Connected to database successfully")
+      }
    }
 }


### PR DESCRIPTION
## Summary
- \`DatabaseHealthCheck\` (the \`@Deprecated\` sibling of \`DatabaseConnectionHealthCheck\`) calls \`ds.connection\`, \`Connection.createStatement()\`, and \`Statement.executeQuery()\` — all blocking JDBC — directly from a \`suspend\` function. Even though the class is deprecated, it is still public API.
- \`HealthCheckRegistry.checkTimeout\` (cooperative cancellation via \`withTimeout\`) cannot interrupt blocking JDBC because cancellation only fires at suspension points, so a slow database hangs the check past its configured timeout.
- Wrap the connection-acquire-execute block in \`runInterruptible(Dispatchers.IO)\`, matching #170 (the same fix on \`DatabaseConnectionHealthCheck\`) and the cancellable-blocking pattern established by the Rabbit / AWS / Mongo sync-client checks.

## Test plan
- [x] \`./gradlew :cohort-api:test --tests DatabaseHealthCheckTest\` — both existing tests pass (default SELECT 1 query, custom query).

🤖 Generated with [Claude Code](https://claude.com/claude-code)