### PR TITLE
Fix FlywayMigrations NPE on pending migrations

### DIFF
--- a/cohort-flyway/src/main/kotlin/com/sksamuel/cohort/flyway/FlywayMigrations.kt
+++ b/cohort-flyway/src/main/kotlin/com/sksamuel/cohort/flyway/FlywayMigrations.kt
@@ -3,6 +3,7 @@ package com.sksamuel.cohort.flyway
 import com.sksamuel.cohort.db.DatabaseMigrationManager
 import com.sksamuel.cohort.db.Migration
 import org.flywaydb.core.Flyway
+import java.time.Instant
 import javax.sql.DataSource
 
 class FlywayMigrations(private val ds: DataSource) : DatabaseMigrationManager {
@@ -19,8 +20,8 @@ class FlywayMigrations(private val ds: DataSource) : DatabaseMigrationManager {
           script = it.script,
           description = it.description,
           checksum = it.checksum.toString(),
-          author = it.installedBy,
-          timestamp = it.installedOn.toInstant(),
+          author = it.installedBy ?: "",
+          timestamp = it.installedOn?.toInstant() ?: Instant.ofEpochMilli(0),
           version = it.version.toString(),
           state = it.state.displayName,
         )


### PR DESCRIPTION
## Summary
- Flyway's \`MigrationInfo.installedBy\` and \`MigrationInfo.installedOn\` return \`null\` for migrations that haven't yet been applied. \`FlywayMigrations.migrations()\` assigns them directly to \`Migration.author\` (non-null \`String\`) and \`Migration.timestamp\` (non-null \`Instant\`), so any pending migration in the changelog makes the call return a Failure with \`IllegalArgumentException\` from Kotlin's data-class null check — and \`/cohort/dbmigration\` 500s instead of listing the migrations.
- Coalesce the nullable Flyway fields with sensible defaults — empty author and \`Instant.ofEpochMilli(0)\` timestamp — matching the pattern already used in \`LiquibaseMigrations\` (which uses the same epoch-zero sentinel for pending changesets).

## Test plan
- [x] \`./gradlew :cohort-flyway:compileKotlin\` succeeds.
- The module has no test source set; the change is a one-line null-safety adjustment matching the LiquibaseMigrations pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)