### PR TITLE
Use ConcurrentHashMap for CohortMetrics counters

### DIFF
--- a/cohort-micrometer/src/main/kotlin/com/sksamuel/cohort/micrometer/CohortMetrics.kt
+++ b/cohort-micrometer/src/main/kotlin/com/sksamuel/cohort/micrometer/CohortMetrics.kt
@@ -6,10 +6,11 @@ import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.binder.MeterBinder
+import java.util.concurrent.ConcurrentHashMap
 
 class CohortMetrics(private val healthCheckRegistry: HealthCheckRegistry) : MeterBinder {
 
-   private val counters = mutableMapOf<Pair<String, HealthStatus>, Counter>()
+   private val counters = ConcurrentHashMap<Pair<String, HealthStatus>, Counter>()
    private val tags = mutableSetOf<Tag>()
 
    /**
@@ -21,7 +22,7 @@ class CohortMetrics(private val healthCheckRegistry: HealthCheckRegistry) : Mete
 
    override fun bindTo(registry: MeterRegistry) {
       healthCheckRegistry.addSubscriber { name, check, result ->
-         val counter = counters.getOrPut(Pair(name, result.status)) {
+         val counter = counters.computeIfAbsent(Pair(name, result.status)) {
             Counter.builder("cohort.healthcheck")
                .tag("name", name)
                .tag("type", check::class.java.name)


### PR DESCRIPTION
## Summary
- \`CohortMetrics.counters\` was a plain \`mutableMapOf\` (\`HashMap\`), but the subscriber callback that mutates it is invoked from \`HealthCheckRegistry.notifySubscribers\`, which fires from \`scope.launch\` on a multi-threaded dispatcher — the registry's default is \`Dispatchers.Default\`. Concurrent \`getOrPut\` on a \`HashMap\` can lose entries, throw \`ConcurrentModificationException\`, or — on older JVMs — spin into an infinite loop.
- Switch the backing map to \`ConcurrentHashMap\`, and use \`computeIfAbsent\` instead of Kotlin's \`Map.getOrPut\` so the \`Counter.builder...register\` lambda runs at most once per \`(name, status)\` key. \`getOrPut\` is non-atomic even on a concurrent map and could otherwise register duplicate meters with the same name+tags.

## Test plan
- [x] \`./gradlew :cohort-micrometer:test\` — existing \`CohortMetricsTest > should collect metrics\` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)