### PR TITLE
Use portable temp dir and UUID for heap dump file

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/heap/Heapdump.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/heap/Heapdump.kt
@@ -4,6 +4,7 @@ import com.sun.management.HotSpotDiagnosticMXBean
 import java.lang.management.ManagementFactory
 import java.nio.file.Files
 import java.nio.file.Paths
+import java.util.UUID
 import kotlin.io.path.deleteIfExists
 
 private const val HOTSPOT_BEAN_NAME = "com.sun.management:type=HotSpotDiagnostic"
@@ -11,7 +12,10 @@ private const val HOTSPOT_BEAN_NAME = "com.sun.management:type=HotSpotDiagnostic
 fun getHeapDump(): Result<ByteArray> = runCatching {
   val server = ManagementFactory.getPlatformMBeanServer()
   val mxBean = ManagementFactory.newPlatformMXBeanProxy(server, HOTSPOT_BEAN_NAME, HotSpotDiagnosticMXBean::class.java)
-  val path = Paths.get("/tmp/heapdump" + System.currentTimeMillis() + ".hprof")
+  val tmpDir = Paths.get(System.getProperty("java.io.tmpdir"))
+  // dumpHeap throws if the target already exists, so use a UUID rather than currentTimeMillis
+  // (two calls in the same millisecond would otherwise collide).
+  val path = tmpDir.resolve("heapdump-${UUID.randomUUID()}.hprof")
   mxBean.dumpHeap(path.toString(), true)
   try {
     Files.readAllBytes(path)


### PR DESCRIPTION
## Summary
- \`getHeapDump\` hard-coded \`/tmp\` as the dump location and used \`System.currentTimeMillis()\` as the uniqueness suffix. Two problems with that:
  1. \`/tmp\` is not writable (or doesn't exist) on Windows by default, so \`getHeapDump\` fails on Windows even when the JVM's HotSpot diagnostic bean is available.
  2. \`HotSpotDiagnosticMXBean.dumpHeap\` throws if the target file already exists. Two concurrent calls landing in the same millisecond collide on the path, and the second call fails with \`IOException\`.
- Read the system temp directory from \`java.io.tmpdir\` (works on Linux, macOS, and Windows) and switch the filename suffix to a \`UUID\` for guaranteed uniqueness across concurrent calls.

## Test plan
- [x] \`./gradlew :cohort-api:compileKotlin\` succeeds.
- The function has no unit test in the repo (it depends on the live HotSpot bean); the change is a small, mechanical adjustment that preserves the same temp-file-write-then-read-and-delete shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)