### PR TITLE
Dispatch SNSHealthCheck blocking AWS call onto Dispatchers.IO

### DIFF
--- a/cohort-aws-sns/src/main/kotlin/com/sksamuel/cohort/aws/sns/SNSHealthCheck.kt
+++ b/cohort-aws-sns/src/main/kotlin/com/sksamuel/cohort/aws/sns/SNSHealthCheck.kt
@@ -6,6 +6,8 @@ import com.amazonaws.services.sns.model.ListTopicsResult
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
 import com.sksamuel.tabby.results.flatMap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
 
 /**
  * A Cohort [HealthCheck] that checks for connectivity to an AWS SNS by listing topics.
@@ -15,8 +17,10 @@ class SNSHealthCheck(
    override val name: String = "aws_sns_topic",
 ) : HealthCheck {
 
-   private fun use(client: AmazonSNS): Result<ListTopicsResult> {
-      return runCatching { client.listTopics() }.also { client.shutdown() }
+   private suspend fun use(client: AmazonSNS): Result<ListTopicsResult> {
+      return runInterruptible(Dispatchers.IO) {
+         runCatching { client.listTopics() }
+      }.also { client.shutdown() }
    }
 
    override suspend fun check(): HealthCheckResult {


### PR DESCRIPTION
## Summary
- \`AmazonSNS.listTopics()\` is a synchronous, blocking HTTP call. \`SNSHealthCheck.use()\` invoked it directly from a \`suspend\` chain — so \`HealthCheckRegistry.checkTimeout\` (\`withTimeout\`, cooperative cancellation) cannot interrupt it: cancellation only fires at suspension points. A slow or unreachable SNS endpoint hangs the check past its configured timeout and ties up a thread on the registry's dispatcher.
- Wrap \`listTopics()\` in \`runInterruptible(Dispatchers.IO)\`, matching the established AWS pattern in \`S3ReadBucketHealthCheck\`, \`S3WriteBucketHealthCheck\`, and \`DynamoDBHealthCheck\`. \`use()\` becomes \`suspend\` so the dispatcher hop can stay inline.

## Test plan
- [x] \`./gradlew :cohort-aws-sns:compileKotlin\` succeeds.
- The module has no test source set; the change is mechanical — same shape as the AWS sibling fixes already in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)