### PR TITLE
Dispatch SQSQueueHealthCheck blocking AWS call onto Dispatchers.IO

### DIFF
--- a/cohort-aws-sqs/src/main/kotlin/com/sksamuel/cohort/aws/sqs/SQSQueueHealthCheck.kt
+++ b/cohort-aws-sqs/src/main/kotlin/com/sksamuel/cohort/aws/sqs/SQSQueueHealthCheck.kt
@@ -6,6 +6,8 @@ import com.amazonaws.services.sqs.model.GetQueueUrlResult
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
 import com.sksamuel.tabby.results.flatMap
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
 
 /**
  * A Cohort [HealthCheck] that checks for connectivity to an AmazonSQS for the given queue.
@@ -16,8 +18,10 @@ class SQSQueueHealthCheck(
    override val name: String = "aws_sqs_queue",
 ) : HealthCheck {
 
-   private fun use(client: AmazonSQS): Result<GetQueueUrlResult> {
-      return runCatching { client.getQueueUrl(queue) }.also { client.shutdown() }
+   private suspend fun use(client: AmazonSQS): Result<GetQueueUrlResult> {
+      return runInterruptible(Dispatchers.IO) {
+         runCatching { client.getQueueUrl(queue) }
+      }.also { client.shutdown() }
    }
 
    override suspend fun check(): HealthCheckResult {


### PR DESCRIPTION
## Summary
- \`AmazonSQS.getQueueUrl(queue)\` is a synchronous, blocking HTTP call. \`SQSQueueHealthCheck.use()\` invoked it directly from a \`suspend\` chain — so \`HealthCheckRegistry.checkTimeout\` (\`withTimeout\`, cooperative cancellation) cannot interrupt it: cancellation only fires at suspension points. A slow or unreachable SQS endpoint hangs the check past its configured timeout and ties up a thread on the registry's dispatcher.
- Wrap \`getQueueUrl()\` in \`runInterruptible(Dispatchers.IO)\`, matching the established AWS pattern in \`S3ReadBucketHealthCheck\`, \`S3WriteBucketHealthCheck\`, and \`DynamoDBHealthCheck\`. \`use()\` becomes \`suspend\` so the dispatcher hop can stay inline.

## Test plan
- [x] \`./gradlew :cohort-aws-sqs:compileKotlin\` succeeds.
- The module has no test source set; the change is mechanical — same shape as the AWS sibling fixes already in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)