### PR TITLE
Use runInterruptible for blocking Elastic health checks

### DIFF
--- a/cohort-elastic/src/main/kotlin/com/sksamuel/cohort/elastic/ElasticClusterCommandCheck.kt
+++ b/cohort-elastic/src/main/kotlin/com/sksamuel/cohort/elastic/ElasticClusterCommandCheck.kt
@@ -5,7 +5,7 @@ package com.sksamuel.cohort.elastic
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runInterruptible
 import org.elasticsearch.client.RestHighLevelClient
 
 /**
@@ -22,7 +22,7 @@ class ElasticClusterCommandCheck(
 
   override suspend fun check(): HealthCheckResult {
     return runCatching {
-      withContext(Dispatchers.IO) {
+      runInterruptible(Dispatchers.IO) {
         command(client)
       }
     }.getOrElse {

--- a/cohort-elastic/src/main/kotlin/com/sksamuel/cohort/elastic/ElasticClusterHealthCheck.kt
+++ b/cohort-elastic/src/main/kotlin/com/sksamuel/cohort/elastic/ElasticClusterHealthCheck.kt
@@ -5,7 +5,7 @@ package com.sksamuel.cohort.elastic
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runInterruptible
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest
 import org.elasticsearch.client.RequestOptions
 import org.elasticsearch.client.RestHighLevelClient
@@ -26,7 +26,7 @@ class ElasticClusterHealthCheck(
   override suspend fun check(): HealthCheckResult {
     return runCatching {
 
-      val health = withContext(Dispatchers.IO) {
+      val health = runInterruptible(Dispatchers.IO) {
         client.cluster().health(ClusterHealthRequest(), RequestOptions.DEFAULT)
       }
 

--- a/cohort-elastic/src/main/kotlin/com/sksamuel/cohort/elastic/ElasticIndexHealthCheck.kt
+++ b/cohort-elastic/src/main/kotlin/com/sksamuel/cohort/elastic/ElasticIndexHealthCheck.kt
@@ -5,7 +5,7 @@ import co.elastic.clients.elasticsearch.core.CountRequest
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.runInterruptible
 
 /**
  * A cohort [HealthCheck] which checks that an elastic index exists, and optionally, that it is not empty.
@@ -23,7 +23,7 @@ class ElasticIndexHealthCheck(
 
    override suspend fun check(): HealthCheckResult {
       return runCatching {
-         withContext(Dispatchers.IO) {
+         runInterruptible(Dispatchers.IO) {
             val count = client.count(CountRequest.Builder().index(index).build())
             if (count.count() == 0L && failIfEmpty) {
                HealthCheckResult.unhealthy("Elastic index '$index' is empty")


### PR DESCRIPTION
## Summary
- All three checks in \`cohort-elastic\` (\`ElasticClusterHealthCheck\`, \`ElasticClusterCommandCheck\`, \`ElasticIndexHealthCheck\`) wrap their blocking client calls in \`withContext(Dispatchers.IO)\`. \`withContext\` switches dispatchers but does **not** propagate the parent's cancellation as a thread interrupt, so \`HealthCheckRegistry.checkTimeout\` (cooperative cancellation via \`withTimeout\`) cannot interrupt a hung Elastic call — cancellation fires only at suspension points, and the inner block doesn't suspend.
- Switch all three to \`runInterruptible(Dispatchers.IO)\`, matching the established pattern in \`RabbitConnectionHealthCheck\`, the AWS checks (S3 / DynamoDB / SNS / SQS), \`MongoConnectionHealthCheck\`'s sync-client path, and the recently-fixed Pulsar / LDAP / Database checks. \`runInterruptible\` additionally interrupts the executing thread on cancellation so Elastic clients that respect \`Thread.interrupt()\` can unwind a hung HTTP call within the configured timeout.

## Test plan
- [x] \`./gradlew :cohort-elastic:test\` — module's tests pass (the existing \`ElasticIndexHealthCheckTest\` exercises the index-check happy path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)