### PR TITLE
Pick least-tagged metric in KafkaProducerCountHealthCheck

### DIFF
--- a/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaProducerCountHealthCheck.kt
+++ b/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaProducerCountHealthCheck.kt
@@ -24,7 +24,12 @@ class KafkaProducerCountHealthCheck(
 
    override suspend fun check(): HealthCheckResult {
 
-      val metric = producer.metrics().values.firstOrNull { it.metricName().name() == metricName }
+      // Pick the most aggregate metric (fewest tags). record-send-total is registered both at
+      // producer level (tags: client-id) and per-topic (tags: client-id, topic); firstOrNull is
+      // non-deterministic between the two. Mirrors AbstractKafkaConsumerMetricHealthCheck.metric().
+      val metric = producer.metrics().values
+         .filter { it.metricName().name() == metricName }
+         .minByOrNull { it.metricName().tags().size }
          ?: return HealthCheckResult.unhealthy("Could not locate kafka metric '${metricName}'", null)
 
       val total = metric.metricValue().toString().toDoubleOrNull()?.roundToLong() ?: 0L

--- a/cohort-kafka/src/test/kotlin/com/sksamuel/cohort/kafka/KafkaProducerCountHealthCheckTest.kt
+++ b/cohort-kafka/src/test/kotlin/com/sksamuel/cohort/kafka/KafkaProducerCountHealthCheckTest.kt
@@ -49,4 +49,35 @@ class KafkaProducerCountHealthCheckTest : FunSpec({
       check.check().status shouldBe HealthStatus.Unhealthy // diff=2
       check.check().status shouldBe HealthStatus.Healthy   // diff=13
    }
+
+   test("prefers the aggregate (least-tagged) metric over per-topic ones") {
+      // record-send-total is registered at producer level (1 tag: client-id) and per-topic
+      // (2 tags: client-id, topic). Verify the producer-level metric is picked: the aggregate
+      // delta meets the minimum, but any single per-topic delta is below it.
+      val producer = mockk<Producer<*, *>>()
+      val producerLevel = MetricName("record-send-total", "producer-metrics", "", mapOf("client-id" to "p1"))
+      val perTopicA = MetricName("record-send-total", "producer-topic-metrics", "", mapOf("client-id" to "p1", "topic" to "a"))
+
+      fun metric(metricName: MetricName, value: Double) = mockk<Metric>().also {
+         every { it.metricName() } returns metricName
+         every { it.metricValue() } returns value
+      }
+
+      // Iteration order puts a per-topic metric first so a firstOrNull-style picker grabs the
+      // wrong metric.
+      val snapshot1 = mapOf(
+         perTopicA to metric(perTopicA, 10.0),
+         producerLevel to metric(producerLevel, 1000.0),
+      )
+      val snapshot2 = mapOf(
+         perTopicA to metric(perTopicA, 30.0),       // per-topic delta = 20
+         producerLevel to metric(producerLevel, 1100.0), // producer-level delta = 100
+      )
+      every { producer.metrics() } returnsMany listOf(snapshot1, snapshot2)
+
+      // min = 50 distinguishes the two: 100 >= 50 (aggregate, healthy) vs 20 < 50 (per-topic, unhealthy).
+      val check = KafkaProducerCountHealthCheck(producer, min = 50)
+      check.check().status shouldBe HealthStatus.Healthy // initial scan
+      check.check().status shouldBe HealthStatus.Healthy // aggregate diff = 100 >= 50
+   }
 })


### PR DESCRIPTION
## Summary
- \`record-send-total\` is registered by the Kafka producer at two levels:
  - \`producer-metrics\` with one tag (\`client-id\`) — aggregate across all topics.
  - \`producer-topic-metrics\` with two tags (\`client-id\`, \`topic\`) — one metric per topic the producer has sent to.
- \`KafkaProducerCountHealthCheck\` used \`producer.metrics().values.firstOrNull { it.metricName().name() == metricName }\`. That is non-deterministic between the producer-level and per-topic instances — the "since last scan" diff could end up reflecting a single topic instead of the producer's total throughput, depending on map iteration order. The existing test only constructs one metric (empty tags), so it didn't exercise this.
- Switch to \`.minByOrNull { it.metricName().tags().size }\`, mirroring \`AbstractKafkaConsumerMetricHealthCheck.metric()\`, so the most aggregate metric wins.

## Test plan
- [x] New regression test \`prefers the aggregate (least-tagged) metric over per-topic ones\` registers both variants with iteration order favouring the per-topic metric, and asserts the aggregate delta is what's read. Verified the test fails on the unfixed source and passes with the fix.
- [x] \`./gradlew :cohort-kafka:test --tests KafkaProducerCountHealthCheckTest\` — all five tests pass (four existing + one new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)