### PR TITLE
Fix RedisConnectionHealthCheck reporting "redis cluster" in messages

### DIFF
--- a/cohort-jedis/src/main/kotlin/com/sksamuel/cohort/redis/RedisConnectionHealthCheck.kt
+++ b/cohort-jedis/src/main/kotlin/com/sksamuel/cohort/redis/RedisConnectionHealthCheck.kt
@@ -19,9 +19,9 @@ class RedisConnectionHealthCheck(
    private val jedis: Jedis,
    private val command: (Connection) -> HealthCheckResult = {
       if (it.ping()) {
-         HealthCheckResult.healthy("Connected to redis cluster")
+         HealthCheckResult.healthy("Connected to Redis")
       } else {
-         HealthCheckResult.unhealthy("Ping to redis cluster failed", null)
+         HealthCheckResult.unhealthy("Ping to Redis failed", null)
       }
    },
    override val name: String = "redis",
@@ -35,9 +35,9 @@ class RedisConnectionHealthCheck(
          tls: Boolean,
          command: (Connection) -> HealthCheckResult = {
             if (it.ping()) {
-               HealthCheckResult.healthy("Connected to redis cluster")
+               HealthCheckResult.healthy("Connected to Redis")
             } else {
-               HealthCheckResult.unhealthy("Ping to redis cluster failed", null)
+               HealthCheckResult.unhealthy("Ping to Redis failed", null)
             }
          }
       ): RedisConnectionHealthCheck {


### PR DESCRIPTION
## Summary
- The default ping command in \`RedisConnectionHealthCheck\` (the **single-instance** Jedis check) was emitting \`"Connected to redis cluster"\` / \`"Ping to redis cluster failed"\`. The class kdoc says "redis instance", the underlying type is \`Jedis\` (not \`JedisCluster\`), and there's a separate \`RedisClusterHealthCheck\` for actual cluster connectivity. The "cluster" wording is a copy-paste leftover that misleads operators reading the health-check output.
- Replace \`"redis cluster"\` with \`"Redis"\` in all four occurrences (the primary constructor's default and the companion-object factory's default). Behavior is unchanged; only the result-message text differs.

## Test plan
- [x] \`./gradlew :cohort-jedis:test --tests RedisConnectionHealthCheckTest\` — all three existing tests pass (none of them assert on the result message text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)