### PR TITLE
Handle nullable version and checksum in FlywayMigrations

### DIFF
--- a/cohort-flyway/src/main/kotlin/com/sksamuel/cohort/flyway/FlywayMigrations.kt
+++ b/cohort-flyway/src/main/kotlin/com/sksamuel/cohort/flyway/FlywayMigrations.kt
@@ -19,10 +19,10 @@ class FlywayMigrations(private val ds: DataSource) : DatabaseMigrationManager {
         Migration(
           script = it.script,
           description = it.description,
-          checksum = it.checksum.toString(),
+          checksum = it.checksum?.toString() ?: "",
           author = it.installedBy ?: "",
           timestamp = it.installedOn?.toInstant() ?: Instant.ofEpochMilli(0),
-          version = it.version.toString(),
+          version = it.version?.toString() ?: "",
           state = it.state.displayName,
         )
       }


### PR DESCRIPTION
## Summary
Follow-up to #173, which handled \`installedBy\` and \`installedOn\` but missed two more nullable fields on Flyway's \`MigrationInfo\`:
- \`getVersion()\` returns \`null\` for repeatable migrations (\`R__*.sql\`) — by Flyway's contract, only versioned migrations have a version.
- \`getChecksum()\` returns \`null\` when Flyway hasn't calculated it yet.

The existing code called \`.toString()\` directly on both, so a user with any repeatable migration in their changelog NPEs at the \`/cohort/dbmigration\` endpoint — the same failure mode #173 fixed for \`installedBy\`/\`installedOn\`, just from a different field.

Coalesce both with \`?.toString() ?: ""\`, matching the empty-string sentinel \`LiquibaseMigrations\` uses for its version field.

## Test plan
- [x] \`./gradlew :cohort-flyway:compileKotlin\` succeeds.
- The module has no test source set; the change is a one-line null-safety adjustment with the same shape as #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)