### PR TITLE
Deregister HealthCheckRegistry shutdown hook on close()

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
@@ -41,11 +41,13 @@ class HealthCheckRegistry(
    var logUnhealthy: Boolean = true
    var checkTimeout: Duration = 10.seconds
 
+   private val shutdownHook = Thread {
+      logger.info("Cohort HealthCheckRegistry shutdown hook is executing")
+      close()
+   }
+
    init {
-      Runtime.getRuntime().addShutdownHook(Thread {
-         logger.info("Cohort HealthCheckRegistry shutdown hook is executing")
-         close()
-      })
+      Runtime.getRuntime().addShutdownHook(shutdownHook)
    }
 
    companion object {
@@ -273,6 +275,10 @@ class HealthCheckRegistry(
    }
 
    override fun close() {
+      // Deregister the shutdown hook so a manually-closed registry can be GC'd. If close() was
+      // invoked from inside the hook, removeShutdownHook throws IllegalStateException because
+      // shutdown is in progress — tolerate that.
+      runCatching { Runtime.getRuntime().removeShutdownHook(shutdownHook) }
       scope.cancel()
       scheduler.shutdown()
       runCatching {

--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/HealthCheckRegistryTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/HealthCheckRegistryTest.kt
@@ -98,4 +98,12 @@ class HealthCheckRegistryTest : FunSpec({
          reg.status().healthchecks["timeout"]?.result?.message shouldBe "timeout failed due to kotlinx.coroutines.TimeoutCancellationException"
       }
    }
+
+   test("close() is idempotent and does not throw") {
+      // close() removes the JVM shutdown hook so a manually-closed registry can be GC'd.
+      // A second close() finds the hook already deregistered — must not throw.
+      val reg = HealthCheckRegistry { }
+      reg.close()
+      reg.close()
+   }
 })


### PR DESCRIPTION
## Summary
- The \`init\` block added an anonymous \`Thread\` to \`Runtime.addShutdownHook\` but never tracked or removed it. Even after a user explicitly calls \`close()\`, the JVM keeps a strong reference to that thread (and through it, the registry) for the rest of the JVM lifetime.
- Consequences:
  - Each registry instance leaks until JVM exit. Visible in test output: multiple \`"Cohort HealthCheckRegistry shutdown hook is executing"\` lines fire at teardown — one per registry the test suite created.
  - Apps that recreate registries (e.g. on config reload) accumulate shutdown hooks and registry state without bound.
- Track the hook in a private field and remove it in \`close()\`. A \`runCatching\` guards the case where \`close()\` is invoked from inside the hook itself — \`Runtime.removeShutdownHook\` throws \`IllegalStateException\` once shutdown is in progress.

## Test plan
- [x] Added a small test that \`close()\` is idempotent — a second call sees the hook already deregistered (\`removeShutdownHook\` would throw \`IllegalArgumentException\` if not guarded) and must not throw.
- [x] \`./gradlew :cohort-api:test --tests HealthCheckRegistryTest\` — all four tests pass.
- Confirmed visible behavior change: in the test run output, only the registries that don't call \`close()\` log \`"shutdown hook is executing"\` at teardown — the new test's registry no longer does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)