### PR TITLE
Distinguish describe errors from missing topic in KafkaTopicHealthCheck

### DIFF
--- a/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaTopicHealthCheck.kt
+++ b/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaTopicHealthCheck.kt
@@ -4,6 +4,7 @@ import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
 import kotlinx.coroutines.future.await
 import org.apache.kafka.clients.admin.Admin
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
 
 /**
  * A [HealthCheck] that checks that a topic exists on a kafka cluster.
@@ -15,15 +16,18 @@ class KafkaTopicHealthCheck(
 ) : HealthCheck {
 
    override suspend fun check(): HealthCheckResult {
-
-      val descriptionMap = runCatching {
-         admin.describeTopics(listOf(topic)).allTopicNames().toCompletionStage().await()
-      }.getOrElse { emptyMap() }
-
-      val topicDescription = descriptionMap[topic]
-      return if (topicDescription == null)
-         HealthCheckResult.unhealthy("Topic $topic does not exist on kafka cluster", null)
-      else
-         HealthCheckResult.healthy("Kafka topic $topicDescription confirmed (${topicDescription.partitions().size} partitions)")
+      return try {
+         val descriptions = admin.describeTopics(listOf(topic)).allTopicNames().toCompletionStage().await()
+         val description = descriptions[topic]
+         if (description == null) {
+            HealthCheckResult.unhealthy("Topic $topic does not exist on kafka cluster", null)
+         } else {
+            HealthCheckResult.healthy("Kafka topic $topic confirmed (${description.partitions().size} partitions)")
+         }
+      } catch (e: UnknownTopicOrPartitionException) {
+         HealthCheckResult.unhealthy("Topic $topic does not exist on kafka cluster", e)
+      } catch (t: Throwable) {
+         HealthCheckResult.unhealthy("Could not query kafka cluster for topic $topic", t)
+      }
    }
 }

--- a/cohort-kafka/src/test/kotlin/com/sksamuel/cohort/kafka/KafkaTopicHealthCheckTest.kt
+++ b/cohort-kafka/src/test/kotlin/com/sksamuel/cohort/kafka/KafkaTopicHealthCheckTest.kt
@@ -1,36 +1,68 @@
-//package com.sksamuel.cohort.kafka
-//
-//import com.sksamuel.cohort.HealthStatus
-//import io.kotest.assertions.nondeterministic.continually
-//import io.kotest.core.extensions.install
-//import io.kotest.core.spec.style.FunSpec
-//import io.kotest.extensions.testcontainers.kafka.KafkaContainerExtension
-//import io.kotest.extensions.testcontainers.kafka.admin
-//import io.kotest.matchers.shouldBe
-//import kotlinx.coroutines.delay
-//import org.apache.kafka.clients.admin.NewTopic
-//import org.testcontainers.containers.KafkaContainer
-//import org.testcontainers.utility.DockerImageName
-//import kotlin.time.Duration.Companion.seconds
-//
-//class KafkaTopicHealthCheckTest : FunSpec({
-//
-//   val kafka = install(KafkaContainerExtension(KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka"))))
-//
-//   test("health check should pass if the topic exists") {
-//
-//      val healthcheck = KafkaTopicHealthCheck(kafka.admin(), "mytopic1")
-//      healthcheck.check().status shouldBe HealthStatus.Unhealthy
-//      kafka.admin().use { it.createTopics(listOf(NewTopic("mytopic1", 1, 1))).all().get() }
-//      delay(1.seconds)
-//      healthcheck.check().status shouldBe HealthStatus.Healthy
-//   }
-//
-//   test("health check should fail if the topic does not exists") {
-//
-//      val healthcheck = KafkaTopicHealthCheck(kafka.admin(), "mytopic2")
-//      continually(5.seconds) {
-//         healthcheck.check().status shouldBe HealthStatus.Unhealthy
-//      }
-//   }
-//})
+package com.sksamuel.cohort.kafka
+
+import com.sksamuel.cohort.HealthStatus
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.every
+import io.mockk.mockk
+import org.apache.kafka.clients.admin.Admin
+import org.apache.kafka.clients.admin.DescribeTopicsResult
+import org.apache.kafka.clients.admin.TopicDescription
+import org.apache.kafka.common.KafkaFuture
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
+import java.util.concurrent.CompletableFuture
+
+class KafkaTopicHealthCheckTest : FunSpec({
+
+   fun adminThatReturns(map: Map<String, TopicDescription>): Admin {
+      val admin = mockk<Admin>()
+      val descResult = mockk<DescribeTopicsResult>()
+      every { admin.describeTopics(any<Collection<String>>()) } returns descResult
+      every { descResult.allTopicNames() } returns KafkaFuture.completedFuture(map)
+      return admin
+   }
+
+   fun adminThatThrows(throwable: Throwable): Admin {
+      val admin = mockk<Admin>()
+      val descResult = mockk<DescribeTopicsResult>()
+      val future = mockk<KafkaFuture<Map<String, TopicDescription>>>()
+      every { admin.describeTopics(any<Collection<String>>()) } returns descResult
+      every { descResult.allTopicNames() } returns future
+      every { future.toCompletionStage() } returns CompletableFuture<Map<String, TopicDescription>>().also {
+         it.completeExceptionally(throwable)
+      }
+      return admin
+   }
+
+   test("returns healthy when topic exists") {
+      val description = mockk<TopicDescription>()
+      every { description.partitions() } returns listOf(mockk(), mockk(), mockk())
+
+      val result = KafkaTopicHealthCheck(adminThatReturns(mapOf("mytopic" to description)), "mytopic").check()
+
+      result.status shouldBe HealthStatus.Healthy
+      result.message shouldContain "Kafka topic mytopic confirmed"
+      result.message shouldContain "3 partitions"
+   }
+
+   test("returns unhealthy with not-found message when describe throws UnknownTopicOrPartitionException") {
+      val ex = UnknownTopicOrPartitionException("nope")
+      val result = KafkaTopicHealthCheck(adminThatThrows(ex), "mytopic").check()
+
+      result.status shouldBe HealthStatus.Unhealthy
+      result.message shouldContain "does not exist"
+      result.cause shouldBe ex
+   }
+
+   test("returns unhealthy with cluster-error message and preserves cause on non-not-found errors") {
+      // Connection failure must NOT be reported as "topic does not exist".
+      val ex = java.io.IOException("connection refused")
+      val result = KafkaTopicHealthCheck(adminThatThrows(ex), "mytopic").check()
+
+      result.status shouldBe HealthStatus.Unhealthy
+      result.message shouldContain "Could not query"
+      result.cause shouldNotBe null
+   }
+})


### PR DESCRIPTION
## Summary
- The old check used \`runCatching { describeTopics... }.getOrElse { emptyMap() }\`. Any exception from \`describeTopics\` — broker unreachable, auth failure, network timeout — was caught and replaced with an empty map, after which the not-found branch fired and the operator was told the topic \`"does not exist"\` with no cause attached. The actual exception was silently dropped, which is misleading and removes the diagnostic information needed to triage cluster issues.
- Replaced with an explicit \`try\` / \`catch\`:
  - \`UnknownTopicOrPartitionException\` keeps the not-found message but now also attaches the exception as the result's cause.
  - Any other \`Throwable\` returns \`"Could not query kafka cluster for topic …"\` with the exception as cause, so operators see the real failure.
  - Also fix a small message-quality bug: the success message interpolated \`\$topicDescription\` (Kafka's verbose \`TopicDescription.toString()\`, which dumps internal/authorizedOperations/etc.) instead of the topic name. Switched to \`\$topic\`.

## Test plan
- [x] Added \`KafkaTopicHealthCheckTest\` covering all three branches (healthy, not-found, cluster-error). Verified each test fails on the unfixed source and passes on the fix.
- [x] \`./gradlew :cohort-kafka:test --tests KafkaTopicHealthCheckTest\` — all three new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)