### PR TITLE
Honor verboseHealthCheckResponse in Vert.x healthcheck endpoint

### DIFF
--- a/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
+++ b/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
@@ -183,22 +183,25 @@ fun Router.cohort(cohort: CohortConfiguration) {
          .handler { context ->
 
             val status = registry.status()
-
-            val results = status.healthchecks.map {
-               ResultJson(
-                  name = it.key,
-                  status = it.value.result.status,
-                  lastCheck = it.value.timestamp.atOffset(ZoneOffset.UTC).toString(),
-                  message = it.value.result.message,
-                  cause = it.value.result.cause?.stackTraceToString(),
-                  consecutiveSuccesses = it.value.consecutiveSuccesses,
-                  consecutiveFailures = it.value.consecutiveFailures,
-               )
-            }
-
             val httpStatus = if (status.healthy) HttpResponseStatus.OK else HttpResponseStatus.SERVICE_UNAVAILABLE
             context.response().setStatusCode(httpStatus.code())
-            context.json(results)
+
+            if (cohort.verboseHealthCheckResponse) {
+               val results = status.healthchecks.map {
+                  ResultJson(
+                     name = it.key,
+                     status = it.value.result.status,
+                     lastCheck = it.value.timestamp.atOffset(ZoneOffset.UTC).toString(),
+                     message = it.value.result.message,
+                     cause = it.value.result.cause?.stackTraceToString(),
+                     consecutiveSuccesses = it.value.consecutiveSuccesses,
+                     consecutiveFailures = it.value.consecutiveFailures,
+                  )
+               }
+               context.json(results)
+            } else {
+               context.response().end(httpStatus.reasonPhrase())
+            }
          }
    }
 }


### PR DESCRIPTION
## Summary
- \`CohortConfiguration.verboseHealthCheckResponse\` is a public \`var\` (default \`true\`) that controls whether the healthcheck endpoint returns a verbose JSON body with per-check details or just the HTTP status description.
- The Ktor routing honors it (\`cohort-ktor/.../endpoints.kt\` line 151–164), but the Vert.x routing never reads the flag — a Vert.x user setting \`verboseHealthCheckResponse = false\` still gets the verbose JSON. Silent no-op of a public config setting.
- Mirror the Ktor branch in \`Router.cohort\`: only emit the \`ResultJson\` list when the flag is \`true\`; otherwise end the response with \`httpStatus.reasonPhrase()\` ("OK" / "Service Unavailable"), matching \`httpStatusCode.description\` on the Ktor side.

## Test plan
- [x] \`./gradlew :cohort-vertx:compileKotlin\` succeeds.
- The module has no test source set; the change is a small, mechanical addition that mirrors the existing Ktor implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)