### PR TITLE
Fix CohortConfiguration doc comments

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/endpoints/CohortConfiguration.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/endpoints/CohortConfiguration.kt
@@ -19,10 +19,10 @@ class CohortConfiguration {
    // set to true to enable the /cohort/memory endpoint which returns memory pool information
    var memory: Boolean = false
 
-   // set to true to enable the /cohort/log endpoint which returns log system information
+   // set to a non-null LogManager to enable the /cohort/logging endpoints which return and update logger levels
    var logManager: LogManager? = null
 
-   // register one or more DataSourceManagers to show information database pools
+   // register one or more DataSourceManagers to show information about database pools
    var dataSources: List<DataSourceManager> = emptyList()
 
    // register one or more DatabaseMigrationManagers to show information about database migrations


### PR DESCRIPTION
## Summary
Two bugs in the comments on \`CohortConfiguration\`'s public fields:

- The \`logManager\` comment said \`"set to true to enable the /cohort/log endpoint which returns log system information"\`. Two issues: the field is a \`LogManager?\`, not a \`Boolean\`, and the actual endpoints registered by both the Ktor and Vert.x routings are \`/cohort/logging\` (GET) and \`/cohort/logging/{name}/{level}\` (PUT) — there is no \`/cohort/log\`. A user reading this comment to discover the URL would call the wrong path.
- The \`dataSources\` comment was missing the word "about": \`"show information database pools"\` → \`"show information about database pools"\` (matching the parallel \`migrations\` comment two lines below).

Comment-only change; no behavior impact.

## Test plan
- [x] \`./gradlew :cohort-api:compileKotlin\` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)