### PR TITLE
Fix grammar in CassandraDriverHealthCheck failure messages

### DIFF
--- a/cohort-cassandra/src/main/kotlin/com/sksamuel/cohort/cassandra/CassandraDriverHealthCheck.kt
+++ b/cohort-cassandra/src/main/kotlin/com/sksamuel/cohort/cassandra/CassandraDriverHealthCheck.kt
@@ -16,10 +16,10 @@ class CassandraDriverHealthCheck(
       }.fold(
          onSuccess = { anyUp ->
             if (anyUp) HealthCheckResult.healthy("Cassandra access successful")
-            else HealthCheckResult.unhealthy("Could not access to Cassandra")
+            else HealthCheckResult.unhealthy("Could not access Cassandra")
          },
          onFailure = { error ->
-            HealthCheckResult.unhealthy("Could not access to Cassandra", error)
+            HealthCheckResult.unhealthy("Could not access Cassandra", error)
          }
       )
 }


### PR DESCRIPTION
## Summary
Both failure branches in \`CassandraDriverHealthCheck\` (no nodes up; exception thrown) emit \`"Could not access to Cassandra"\` — the "to" makes it ungrammatical, since "access" is a verb here. Drop the "to" so the message reads naturally: \`"Could not access Cassandra"\`. The success message ("Cassandra access successful") already uses "access" correctly as a noun.

User-visible string only; no behavior change.

## Test plan
- [x] \`./gradlew :cohort-cassandra:compileKotlin\` succeeds.
- Confirmed no tests assert on the message text (\`grep "Could not access to"\` returns nothing repo-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)