### PR TITLE
Fix succesfully typo in RedisConnectionHealthCheck kdoc

### DIFF
--- a/cohort-jedis/src/main/kotlin/com/sksamuel/cohort/redis/RedisConnectionHealthCheck.kt
+++ b/cohort-jedis/src/main/kotlin/com/sksamuel/cohort/redis/RedisConnectionHealthCheck.kt
@@ -11,7 +11,7 @@ import redis.clients.jedis.Jedis
 
 /**
  * A [HealthCheck] that checks that a connection can be made to a redis instance and a command
- * invoked succesfully.
+ * invoked successfully.
  *
  * @param command an optional command to execute against the redis instance. Defaults to ping.
  */


### PR DESCRIPTION
Comment-only fix: `succesfully` → `successfully` in the class kdoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)