### PR TITLE
Fix thresold typo in Kafka consumer require() messages

### DIFF
--- a/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaConsumerRecordsConsumedHealthCheck.kt
+++ b/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaConsumerRecordsConsumedHealthCheck.kt
@@ -22,7 +22,7 @@ class KafkaConsumerRecordsConsumedHealthCheck(
 ) : AbstractKafkaConsumerMetricHealthCheck(consumer) {
 
    init {
-      require(minRecords > 0) { "The minimum thresold is > 0" }
+      require(minRecords > 0) { "The minimum threshold is > 0" }
    }
 
    private val metricName = "records-consumed-total"

--- a/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaConsumerRecordsConsumedRateHealthCheck.kt
+++ b/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaConsumerRecordsConsumedRateHealthCheck.kt
@@ -21,7 +21,7 @@ class KafkaConsumerRecordsConsumedRateHealthCheck(
 ) : AbstractKafkaConsumerMetricHealthCheck(consumer) {
 
    init {
-      require(minThreshold > 0.0) { "The minimum thresold is > 0.0" }
+      require(minThreshold > 0.0) { "The minimum threshold is > 0.0" }
    }
 
    private val metricName = "records-consumed-rate"


### PR DESCRIPTION
Two `require()` preconditions in cohort-kafka emitted `"The minimum thresold is …"`. `thresold` → `threshold`. These messages surface to users who pass an invalid arg to the consumer health check constructors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)