### PR TITLE
Remove unused names field from HealthCheckRegistry

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
@@ -27,7 +27,6 @@ class HealthCheckRegistry(
 
    private val scope = CoroutineScope(dispatcher)
    private val scheduler = Executors.newScheduledThreadPool(1, NamedThreadFactory("cohort-healthcheck-scheduler"))
-   private val names = mutableSetOf<String>()
 
    private val checks = ConcurrentHashMap<String, HealthCheck>()
    private val statuses = ConcurrentHashMap<String, HealthCheckStatus>()


### PR DESCRIPTION
`private val names = mutableSetOf<String>()` was declared at the top of `HealthCheckRegistry` but never read or written by anything in the file or anywhere else in the project — duplicate-name detection on `register()` goes through `checks.containsKey`, not `names`. Dropped the dead field. `HealthCheckRegistryTest` (3 tests) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)