### PR TITLE
Move RabbitConnectionHealthCheckTest out of the mongo package

### DIFF
--- a/cohort-rabbit/src/test/kotlin/com/sksamuel/cohort/rabbit/RabbitConnectionHealthCheckTest.kt
+++ b/cohort-rabbit/src/test/kotlin/com/sksamuel/cohort/rabbit/RabbitConnectionHealthCheckTest.kt
@@ -1,9 +1,8 @@
-package com.sksamuel.cohort.mongo
+package com.sksamuel.cohort.rabbit
 
 import com.rabbitmq.client.Connection
 import com.rabbitmq.client.ConnectionFactory
 import com.sksamuel.cohort.HealthCheckResult
-import com.sksamuel.cohort.rabbit.RabbitConnectionHealthCheck
 import io.kotest.core.extensions.install
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.extensions.testcontainers.TestContainerSpecExtension


### PR DESCRIPTION
The test was sitting at `cohort-rabbit/src/test/kotlin/com/sksamuel/cohort/mongo/RabbitConnectionHealthCheckTest.kt` with `package com.sksamuel.cohort.mongo` — but it tests `RabbitConnectionHealthCheck` and lives in the cohort-rabbit module. The `mongo` package was a copy-paste leftover.

Moved to `.../rabbit/RabbitConnectionHealthCheckTest.kt` with `package com.sksamuel.cohort.rabbit`, alongside the existing `RabbitQueueHealthCheckTest`. Removed the now-redundant `com.sksamuel.cohort.rabbit.RabbitConnectionHealthCheck` import since the test is now in the same package as the class.

`./gradlew :cohort-rabbit:compileTestKotlin` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)