### PR TITLE
Handle nullable pathParam in Vert.x logging PUT handler

### DIFF
--- a/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
+++ b/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
@@ -101,6 +101,10 @@ fun Router.cohort(cohort: CohortConfiguration) {
          .handler { context ->
             val name = context.pathParam("name")
             val level = context.pathParam("level")
+            if (name == null || level == null) {
+               context.response().setStatusCode(400).end()
+               return@handler
+            }
             manager.set(name, level).fold(
                { context.json(it) },
                { context.response().setStatusCode(500).end() },


### PR DESCRIPTION
## Summary
Vert.x's `RoutingContext.pathParam` returns `String?`, but the previous code passed the result directly to `LogManager.set(String, String)`. The Kotlin compiler emitted two warnings on the call site:

```
w: vertx.kt:104:25 Java type mismatch: inferred type is 'String?', but 'String' was expected.
w: vertx.kt:104:31 Java type mismatch: inferred type is 'String?', but 'String' was expected.
```

Although the path pattern `/{name}/{level}` guarantees both params are present at runtime when the route matches, the unchecked nullable pass-through is exactly the kind of platform-type sloppiness that turns into a runtime NPE later. Check both for null and respond with 400 Bad Request if either is missing. The Ktor sibling already does the equivalent via `call.parameters.getOrFail`.

## Test plan
- [x] `./gradlew :cohort-vertx:compileKotlin` succeeds with no warnings on this file (the two type-mismatch warnings on line 104 are gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)