### PR TITLE
Make S3WriteBucketHealthCheck cleanup best-effort

### DIFF
--- a/cohort-aws-s3/src/main/kotlin/com/sksamuel/cohort/aws/s3/S3WriteBucketHealthCheck.kt
+++ b/cohort-aws-s3/src/main/kotlin/com/sksamuel/cohort/aws/s3/S3WriteBucketHealthCheck.kt
@@ -22,9 +22,16 @@ class S3WriteBucketHealthCheck(
       return runInterruptible(Dispatchers.IO) {
          runCatching {
             val key = "cohort_" + Random.nextInt(0, Integer.MAX_VALUE)
-            client.putObject(bucketName, key, "test")
-            client.deleteObject(bucketName, key)
-         }
+            try {
+               client.putObject(bucketName, key, "test")
+            } finally {
+               // Best-effort cleanup. The check's documented purpose is to verify write
+               // access (s3:PutObject); a missing s3:DeleteObject permission or a transient
+               // cleanup failure should not mask a successful put as unhealthy. Swallow
+               // any delete error here.
+               runCatching { client.deleteObject(bucketName, key) }
+            }
+         }.map { }
       }.also { client.shutdown() }
    }
 


### PR DESCRIPTION
## Summary
The check did `putObject`-then-`deleteObject` inside a single `runCatching`. If `putObject` succeeded but `deleteObject` threw — for example, when the IAM principal has `s3:PutObject` but **not** `s3:DeleteObject`, or there's a transient cleanup failure — the check reported unhealthy. Two consequences:

- **False-negative health**: write actually works, but the user sees `"Could not write to bucket"`.
- The `cohort_<random>` test object stays in the bucket and accumulates across calls.

The class kdoc only promises "checks for connectivity and write permissions" — delete permission is not part of the contract.

Wrapped the `deleteObject` in its own `runCatching` inside a `finally` so:

- **put failure**: outer `runCatching` catches the put exception, `finally` still attempts (and swallows) the cleanup.
- **put success**: `try` evaluates, `finally` attempts cleanup, any cleanup error is swallowed and the check reports healthy.

`.map { }` converts `Result<PutObjectResult>` back to `Result<Unit>` so the public signature stays the same.

## Test plan
- [x] `./gradlew :cohort-aws-s3:compileKotlin` succeeds.
- The module has no test source set; the change is mechanical and the new behavior matches the documented contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)