### PR TITLE
Align register(check, delay) deprecation ReplaceWith with its message

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
@@ -107,7 +107,7 @@ class HealthCheckRegistry(
     */
    @Deprecated(
       "Use register(check, initialDelay, checkInterval) to be explicit",
-      ReplaceWith("register(check.name, check, delay, delay)")
+      ReplaceWith("register(check, delay, delay)")
    )
    fun register(
       check: HealthCheck,


### PR DESCRIPTION
## Summary
The deprecation on `HealthCheckRegistry.register(check, delay)` was internally inconsistent:

```kotlin
@Deprecated(
   "Use register(check, initialDelay, checkInterval) to be explicit",  // 3-arg unnamed form
   ReplaceWith("register(check.name, check, delay, delay)")              // 4-arg name form
)
```

The IDE quick-fix substitutes one shape while the message tells the user to use a different shape. The sibling deprecation 25 lines below (`register(name, check, delay)`) is consistent — both message and `ReplaceWith` reference the 4-arg form.

Bring this one in line by changing the `ReplaceWith` to `register(check, delay, delay)` so it matches its own message. Behaviour unchanged: the implementation body still delegates to the 4-arg name-based `register`; the underlying call path is the same.

## Test plan
- [x] `./gradlew :cohort-api:test --tests HealthCheckRegistryTest` — all four tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)