### PR TITLE
Fix inverted comparison in MaxFileDescriptorsHealthCheck

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/MaxFileDescriptorsHealthCheck.kt
@@ -8,7 +8,7 @@ import java.lang.management.ManagementFactory
 /**
  * A Cohort [HealthCheck] for the number of max file descriptors.
  *
- * The check is considered healthy if the max count is <= [requiredMaxDescriptors].
+ * The check is considered healthy if the max count is >= [requiredMaxDescriptors].
  */
 class MaxFileDescriptorsHealthCheck(private val requiredMaxDescriptors: Int) : HealthCheck {
 
@@ -19,7 +19,7 @@ class MaxFileDescriptorsHealthCheck(private val requiredMaxDescriptors: Int) : H
   override suspend fun check(): HealthCheckResult {
     val files = bean.maxFileDescriptorCount
     val msg = "Max file descriptors $files [required at least $requiredMaxDescriptors]"
-    return if (files < requiredMaxDescriptors) {
+    return if (files >= requiredMaxDescriptors) {
       HealthCheckResult.healthy(msg)
     } else {
       HealthCheckResult.unhealthy(msg, null)


### PR DESCRIPTION
## Summary
- `MaxFileDescriptorsHealthCheck` reported **healthy** when the OS-configured max FD count was *below* the required value, and **unhealthy** when it was at/above.
- The class name, the parameter `requiredMaxDescriptors`, the message `"required at least ..."`, and the KDoc all imply the opposite: the OS limit should be at least the required value.
- Flipped the branch and corrected the KDoc (`<=` → `>=`).

Before: with `requiredMaxDescriptors=10000`, a host with a 1024 FD limit was silently reported healthy.

## Test plan
- [ ] Existing tests pass
- [ ] Unit test for both branches if desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)