### PR TITLE
Treat unavailable CPU/load metrics as unhealthy

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/cpu/ProcessCpuHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/cpu/ProcessCpuHealthCheck.kt
@@ -19,6 +19,9 @@ class ProcessCpuHealthCheck(private val maxLoad: Double) : HealthCheck {
 
    override suspend fun check(): HealthCheckResult {
       val load = bean.processCpuLoad
+      // OperatingSystemMXBean returns a negative value (typically -1.0) when the metric is
+      // not available. Without this guard, an unsupported platform silently reports healthy.
+      if (load < 0.0) return HealthCheckResult.unhealthy("Process CPU load is unavailable [$load]", null)
       val msg = "Process CPU $load [max load $maxLoad]"
       return if (load < maxLoad) {
          HealthCheckResult.healthy(msg)

--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/SystemCpuHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/SystemCpuHealthCheck.kt
@@ -19,6 +19,9 @@ class SystemCpuHealthCheck(private val maxLoad: Double) : HealthCheck {
 
   override suspend fun check(): HealthCheckResult {
     val load = bean.systemCpuLoad
+    // OperatingSystemMXBean returns a negative value (typically -1.0) when the metric is
+    // not available. Without this guard, an unsupported platform silently reports healthy.
+    if (load < 0.0) return HealthCheckResult.unhealthy("System CPU load is unavailable [$load]", null)
     return if (load < maxLoad) {
       HealthCheckResult.healthy("System CPU is below threshold [$load < $maxLoad]")
     } else {

--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/SystemLoadHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/SystemLoadHealthCheck.kt
@@ -18,6 +18,10 @@ class SystemLoadHealthCheck(private val maxLoad: Double) : HealthCheck {
 
   override suspend fun check(): HealthCheckResult {
     val load = bean.systemLoadAverage
+    // OperatingSystemMXBean returns a negative value (typically -1.0) when the system load
+    // average is not available on the platform (notably some Windows JVMs). Without this guard,
+    // such platforms silently report healthy.
+    if (load < 0.0) return HealthCheckResult.unhealthy("System load average is unavailable [$load]", null)
     return if (load < maxLoad) {
       HealthCheckResult.healthy("System load is below threshold [$load < $maxLoad]")
     } else {


### PR DESCRIPTION
## Summary
`SystemCpuHealthCheck`, `ProcessCpuHealthCheck`, and `SystemLoadHealthCheck` all compare a metric against `maxLoad ∈ [0,1]` without first checking for the sentinel `-1.0` that `OperatingSystemMXBean` returns when the metric is unavailable. Since `-1.0 < maxLoad` is always true, an unsupported platform silently reports **healthy**.

Add an explicit guard that reports unhealthy with a clear "metric unavailable" message.

## Test plan
- [ ] Existing tests pass
- [ ] Run on a JVM/platform where one of the metrics is unavailable and confirm the check goes unhealthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)