### PR TITLE
Reject unknown log levels in LogbackManager.set

### DIFF
--- a/cohort-logback/src/main/kotlin/com/sksamuel/cohort/logback/LogbackManager.kt
+++ b/cohort-logback/src/main/kotlin/com/sksamuel/cohort/logback/LogbackManager.kt
@@ -24,6 +24,9 @@ object LogbackManager : LogManager {
   override fun set(name: String, level: String) = runCatching {
     val context = LoggerFactory.getILoggerFactory() as LoggerContext
     val logger = context.getLogger(name)
-    logger.level = Level.toLevel(level)
+    // Level.toLevel(String) defaults to DEBUG on unknown input, which silently lowers the
+    // log level instead of reporting an error. Use the explicit two-arg variant with a null
+    // default and fail loudly if the level can't be parsed.
+    logger.level = Level.toLevel(level, null) ?: error("Unknown log level: $level")
   }
 }


### PR DESCRIPTION
## Summary
\`Level.toLevel(String)\` (single-arg) defaults to **DEBUG** on unknown input. A typo like \`PUT /cohort/logging/com.foo/INFOX\` would return success and silently set the logger to DEBUG in production. Use the two-arg variant with a null default and surface an error if the level can't be parsed.

## Test plan
- [ ] Existing tests pass
- [ ] PUT with an unknown level returns 500 instead of silently setting DEBUG

🤖 Generated with [Claude Code](https://claude.com/claude-code)