### PR TITLE
Reject unknown log levels in Log4j2Manager.set

### DIFF
--- a/cohort-log4j2/src/main/kotlin/com/sksamuel/cohort/log4j2/Log4j2Manager.kt
+++ b/cohort-log4j2/src/main/kotlin/com/sksamuel/cohort/log4j2/Log4j2Manager.kt
@@ -29,6 +29,10 @@ object Log4j2Manager : LogManager {
   }
 
   override fun set(name: String, level: String): Result<Unit> = runCatching {
-    Configurator.setLevel(name, Level.getLevel(level))
+    // Level.getLevel returns null for unknown level strings. Configurator.setLevel(name, null)
+    // would silently no-op (or reset the level) and the runCatching block would still report
+    // success. Fail loudly instead, so a typo via PUT /logging/{name}/{level} surfaces as an error.
+    val resolved = Level.getLevel(level) ?: error("Unknown log level: $level")
+    Configurator.setLevel(name, resolved)
   }
 }


### PR DESCRIPTION
## Summary
`Level.getLevel(String)` returns `null` for unknown level names, and `Configurator.setLevel(name, null)` silently no-ops. The `runCatching` block then reports success, so a typo via `PUT /cohort/logging/{name}/{level}` looks like it succeeded. Fail loudly when the level can't be resolved.

Sibling fix to #203 for the logback module.

## Test plan
- [ ] Existing tests pass
- [ ] PUT with an unknown level returns 500 instead of silently doing nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)