### PR TITLE
Return empty 200 from Vert.x logging PUT instead of JSON-serializing Unit

### DIFF
--- a/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
+++ b/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
@@ -106,7 +106,9 @@ fun Router.cohort(cohort: CohortConfiguration) {
                return@handler
             }
             manager.set(name, level).fold(
-               { context.json(it) },
+               // The success value is Unit; serializing it as JSON produces a nonsensical body.
+               // Mirror the Ktor endpoint, which returns an empty 200 OK on success.
+               { context.response().setStatusCode(200).end() },
                { context.response().setStatusCode(500).end() },
             )
          }


### PR DESCRIPTION
## Summary
`LogManager.set` returns `Result<Unit>`. The Vert.x success handler called `context.json(it)` with `it == Unit`, producing a nonsensical body. The Ktor sibling endpoint already returns an empty 200 — make the Vert.x side consistent.

## Test plan
- [ ] Existing tests pass
- [ ] PUT /cohort/logging/{name}/{level} returns 200 with empty body

🤖 Generated with [Claude Code](https://claude.com/claude-code)