### PR TITLE
Atomically detect duplicate name in HealthCheckRegistry.register

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
@@ -152,8 +152,10 @@ class HealthCheckRegistry(
       checkInterval: Duration,
    ): HealthCheckRegistry {
 
-      if (checks.containsKey(name)) error("Check $name already registered")
-      checks.putIfAbsent(name, check)
+      // Atomic check-and-insert. Using containsKey then putIfAbsent left a TOCTOU window where
+      // two concurrent register() calls with the same name could both pass the contains check,
+      // schedule independent jobs, and silently share the first-stored HealthCheck.
+      if (checks.putIfAbsent(name, check) != null) error("Check $name already registered")
 
       listeners.forEach { it.registered(name, initialDelay, checkInterval) }
 


### PR DESCRIPTION
## Summary
\`register()\` did \`containsKey(name)\` then \`putIfAbsent(name, check)\`. Two concurrent registrations with the same name could both pass the contains check, then schedule independent jobs while sharing whichever HealthCheck won the race into the map.

Use \`putIfAbsent\` return value directly so insert and duplicate-detection are atomic.

## Test plan
- [ ] Existing tests pass
- [ ] Concurrent register-of-same-name now throws on the second caller

🤖 Generated with [Claude Code](https://claude.com/claude-code)