### PR TITLE
Compare DiskSpaceHealthCheck on raw percentage, not roundToInt

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/DiskSpaceHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/DiskSpaceHealthCheck.kt
@@ -5,7 +5,6 @@ import com.sksamuel.cohort.HealthCheckResult
 import java.nio.file.FileStore
 import java.nio.file.FileSystems
 import java.nio.file.Files
-import kotlin.math.roundToInt
 
 /**
  * A Cohort [HealthCheck] that examines disk space on the given [FileStore].
@@ -27,11 +26,14 @@ class DiskSpaceHealthCheck(
 
   override suspend fun check(): HealthCheckResult {
     return try {
-      val availablePercent = (fileStore.usableSpace.toDouble() / fileStore.totalSpace.toDouble() * 100).roundToInt()
+      // Compare on the raw Double so values just below the threshold (e.g. 9.5% with a
+      // 10.0% threshold) aren't rounded up and reported as healthy.
+      val availablePercent = fileStore.usableSpace.toDouble() / fileStore.totalSpace.toDouble() * 100
+      val msg = "Available disk space is %.2f%% on %s".format(availablePercent, fileStore.name())
       if (availablePercent < minFreeSpacePercentage)
-        HealthCheckResult.unhealthy("Available disk space is $availablePercent% on ${fileStore.name()}", null)
+        HealthCheckResult.unhealthy(msg, null)
       else
-        HealthCheckResult.healthy("Available disk space is $availablePercent% on ${fileStore.name()}")
+        HealthCheckResult.healthy(msg)
     } catch (t: Throwable) {
       HealthCheckResult.unhealthy("Error querying disk space on ${fileStore.name()}", t)
     }


### PR DESCRIPTION
## Summary
The check rounded \`availablePercent\` to \`Int\` before comparing it against a \`Double\` threshold. With \`minFreeSpacePercentage = 10.0\`, an actual 9.5% free disk rounded up to \`10\` and was reported **healthy** at the cutoff. Compare on the raw \`Double\` and format the displayed value with two decimal places.

## Test plan
- [ ] Existing tests pass
- [ ] 9.5% free disk with threshold 10.0% now reports unhealthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)