### PR TITLE
Fix KDoc typo 'get file system' in DiskSpaceHealthCheck.defaults

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/DiskSpaceHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/DiskSpaceHealthCheck.kt
@@ -49,7 +49,7 @@ class DiskSpaceHealthCheck(
     }
 
     /**
-     * Returns a [DiskSpaceHealthCheck] for each filestore in the get file system.
+     * Returns a [DiskSpaceHealthCheck] for each filestore in the default file system.
      */
     fun defaults(minFreeSpacePercentage: Double = 10.0): List<HealthCheck> =
       FileSystems.getDefault().fileStores.map { DiskSpaceHealthCheck(it, minFreeSpacePercentage) }


### PR DESCRIPTION
Replace `get file system` with `default file system` in the KDoc for `defaults`. Trivial copy-edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)