### PR TITLE
Handle null version for Flyway repeatable migrations

### DIFF
--- a/cohort-flyway/src/main/kotlin/com/sksamuel/cohort/flyway/FlywayMigrations.kt
+++ b/cohort-flyway/src/main/kotlin/com/sksamuel/cohort/flyway/FlywayMigrations.kt
@@ -22,7 +22,10 @@ class FlywayMigrations(private val ds: DataSource) : DatabaseMigrationManager {
           checksum = it.checksum.toString(),
           author = it.installedBy ?: "",
           timestamp = it.installedOn?.toInstant() ?: Instant.ofEpochMilli(0),
-          version = it.version.toString(),
+          // Repeatable migrations have a null version. Without the safe-call this NPEs (or
+          // records the literal string "null") in the same way the pending-migration NPE
+          // fixed in 5ea010d did.
+          version = it.version?.toString() ?: "",
           state = it.state.displayName,
         )
       }


### PR DESCRIPTION
## Summary
Flyway's \`MigrationInfo.getVersion()\` returns null for repeatable migrations. The previous \`it.version.toString()\` either NPE'd (platform type inferred non-null) or recorded the literal string \`\"null\"\`. Use a safe call with empty fallback — same fix shape as the pending-migration NPE in 5ea010d.

## Test plan
- [ ] Existing tests pass
- [ ] Migration list with a repeatable migration no longer throws and shows an empty version

🤖 Generated with [Claude Code](https://claude.com/claude-code)