### PR TITLE
Convert DBCP timeouts from seconds to milliseconds

### DIFF
--- a/cohort-dbcp/src/main/kotlin/com/sksamuel/cohort/dbcp/manager.kt
+++ b/cohort-dbcp/src/main/kotlin/com/sksamuel/cohort/dbcp/manager.kt
@@ -21,7 +21,10 @@ class ApacheDBCPDataSourceManager(private val ds: BasicDataSource) : DataSourceM
         idleConnections = ds.numIdle,
         totalConnections = ds.numActive + ds.numIdle,
         threadsAwaitingConnection = -1,
-        connectionTimeoutMs = ds.loginTimeout.toLong(),
+        // DataSource.loginTimeout and BasicDataSource.validationQueryTimeout are in seconds
+        // (per CommonDataSource / DBCP2), while the DataSourceInfo fields are documented as
+        // milliseconds. Convert so observability shows the real values.
+        connectionTimeoutMs = ds.loginTimeout.toLong() * 1000,
         idleTimeoutMs = ds.minEvictableIdleTimeMillis,
         maxLifetimeMs = ds.maxConnLifetimeMillis,
         leakDetectionThreshold = -1,
@@ -32,7 +35,7 @@ class ApacheDBCPDataSourceManager(private val ds: BasicDataSource) : DataSourceM
         testOnCreate = ds.testOnCreate,
         maximumPoolSize = ds.maxTotal,
         maximumIdle = ds.maxIdle,
-        validationTimeoutMs = ds.validationQueryTimeout.toLong(),
+        validationTimeoutMs = ds.validationQueryTimeout.toLong() * 1000,
       )
     }
   }


### PR DESCRIPTION
## Summary
\`DataSource.loginTimeout\` and \`BasicDataSource.validationQueryTimeout\` are both **seconds** (per \`CommonDataSource\` and DBCP2). They were being stored directly into \`DataSourceInfo.connectionTimeoutMs\` and \`validationTimeoutMs\` (documented as ms), so the reported values were 1000× too small. Multiply by 1000.

## Test plan
- [ ] Existing tests pass
- [ ] \`/cohort/datasources\` shows correct ms values

🤖 Generated with [Claude Code](https://claude.com/claude-code)