### PR TITLE
Use try/finally to shut down AWS clients on cancellation

### DIFF
--- a/cohort-aws-s3/src/main/kotlin/com/sksamuel/cohort/aws/s3/S3ReadBucketHealthCheck.kt
+++ b/cohort-aws-s3/src/main/kotlin/com/sksamuel/cohort/aws/s3/S3ReadBucketHealthCheck.kt
@@ -20,11 +20,18 @@ class S3ReadBucketHealthCheck(
 ) : HealthCheck {
 
    private suspend fun use(client: AmazonS3): Result<HeadBucketResult> {
-      return runInterruptible(Dispatchers.IO) {
-         runCatching {
-            client.headBucket(HeadBucketRequest(bucketName))
+      // `.also { client.shutdown() }` does not run if the inner runInterruptible block
+      // is cancelled (it throws CancellationException before returning a value). Use
+      // try/finally to guarantee the client is closed even on cancellation.
+      return try {
+         runInterruptible(Dispatchers.IO) {
+            runCatching {
+               client.headBucket(HeadBucketRequest(bucketName))
+            }
          }
-      }.also { client.shutdown() }
+      } finally {
+         runCatching { client.shutdown() }
+      }
    }
 
    override suspend fun check(): HealthCheckResult {

--- a/cohort-aws-s3/src/main/kotlin/com/sksamuel/cohort/aws/s3/S3WriteBucketHealthCheck.kt
+++ b/cohort-aws-s3/src/main/kotlin/com/sksamuel/cohort/aws/s3/S3WriteBucketHealthCheck.kt
@@ -19,13 +19,25 @@ class S3WriteBucketHealthCheck(
 ) : HealthCheck {
 
    private suspend fun use(client: AmazonS3): Result<Unit> {
-      return runInterruptible(Dispatchers.IO) {
-         runCatching {
-            val key = "cohort_" + Random.nextInt(0, Integer.MAX_VALUE)
-            client.putObject(bucketName, key, "test")
-            client.deleteObject(bucketName, key)
+      // `.also { client.shutdown() }` does not run if the inner runInterruptible block
+      // is cancelled (it throws CancellationException before returning a value). Use
+      // try/finally to guarantee the client is closed even on cancellation.
+      return try {
+         runInterruptible(Dispatchers.IO) {
+            runCatching {
+               val key = "cohort_" + Random.nextInt(0, Integer.MAX_VALUE)
+               try {
+                  client.putObject(bucketName, key, "test")
+               } finally {
+                  // Always best-effort delete the test object so a put-then-delete failure or
+                  // interrupt between the two doesn't leave orphan cohort_* keys in the bucket.
+                  runCatching { client.deleteObject(bucketName, key) }
+               }
+            }
          }
-      }.also { client.shutdown() }
+      } finally {
+         runCatching { client.shutdown() }
+      }
    }
 
    override suspend fun check(): HealthCheckResult {

--- a/cohort-aws-sns/src/main/kotlin/com/sksamuel/cohort/aws/sns/SNSHealthCheck.kt
+++ b/cohort-aws-sns/src/main/kotlin/com/sksamuel/cohort/aws/sns/SNSHealthCheck.kt
@@ -18,9 +18,16 @@ class SNSHealthCheck(
 ) : HealthCheck {
 
    private suspend fun use(client: AmazonSNS): Result<ListTopicsResult> {
-      return runInterruptible(Dispatchers.IO) {
-         runCatching { client.listTopics() }
-      }.also { client.shutdown() }
+      // `.also { client.shutdown() }` does not run if the inner runInterruptible block
+      // is cancelled (it throws CancellationException before returning a value). Use
+      // try/finally to guarantee the client is closed even on cancellation.
+      return try {
+         runInterruptible(Dispatchers.IO) {
+            runCatching { client.listTopics() }
+         }
+      } finally {
+         runCatching { client.shutdown() }
+      }
    }
 
    override suspend fun check(): HealthCheckResult {

--- a/cohort-aws-sqs/src/main/kotlin/com/sksamuel/cohort/aws/sqs/SQSQueueHealthCheck.kt
+++ b/cohort-aws-sqs/src/main/kotlin/com/sksamuel/cohort/aws/sqs/SQSQueueHealthCheck.kt
@@ -19,9 +19,16 @@ class SQSQueueHealthCheck(
 ) : HealthCheck {
 
    private suspend fun use(client: AmazonSQS): Result<GetQueueUrlResult> {
-      return runInterruptible(Dispatchers.IO) {
-         runCatching { client.getQueueUrl(queue) }
-      }.also { client.shutdown() }
+      // `.also { client.shutdown() }` does not run if the inner runInterruptible block
+      // is cancelled (it throws CancellationException before returning a value). Use
+      // try/finally to guarantee the client is closed even on cancellation.
+      return try {
+         runInterruptible(Dispatchers.IO) {
+            runCatching { client.getQueueUrl(queue) }
+         }
+      } finally {
+         runCatching { client.shutdown() }
+      }
    }
 
    override suspend fun check(): HealthCheckResult {


### PR DESCRIPTION
## Summary
S3 read+write, SNS and SQS health checks all followed:
\`\`\`kotlin
runInterruptible(Dispatchers.IO) { runCatching { ... } }
   .also { client.shutdown() }
\`\`\`
\`.also\` does not run when \`runInterruptible\` is cancelled — the block throws \`CancellationException\` before returning a value. Under cancellation pressure (registry \`checkTimeout\` firing, etc.), the AWS client and its HTTP connection pool / executor threads leak.

Switch to \`try/finally\` so shutdown always runs. In \`S3WriteBucketHealthCheck\` also wrap \`deleteObject\` in a finally so a failure between put and delete doesn't leave orphan \`cohort_*\` keys.

## Test plan
- [ ] Existing tests pass
- [ ] Cancel a check mid-flight; confirm no client leak (e.g. via thread dump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)