### PR TITLE
Verify Pulsar cluster list is non-empty before reporting healthy

### DIFF
--- a/cohort-pulsar/src/main/kotlin/com/sksamuel/cohort/pulsar/PulsarHealthCheck.kt
+++ b/cohort-pulsar/src/main/kotlin/com/sksamuel/cohort/pulsar/PulsarHealthCheck.kt
@@ -21,10 +21,15 @@ class PulsarHealthCheck(
 
    override suspend fun check(): HealthCheckResult {
       return runCatching {
-         runInterruptible(Dispatchers.IO) {
+         val clusters = runInterruptible(Dispatchers.IO) {
             client.clusters().getClusters()
          }
-         HealthCheckResult.healthy("Connected to Pulsar")
+         // An empty cluster list means the broker is reachable but unconfigured (no clusters
+         // registered). Without this check, a misconfigured broker silently reports healthy.
+         if (clusters.isNullOrEmpty())
+            HealthCheckResult.unhealthy("Pulsar reachable but reports no clusters", null)
+         else
+            HealthCheckResult.healthy("Connected to Pulsar; clusters=${clusters.joinToString(",")}")
       }.getOrElse { HealthCheckResult.unhealthy("Could not connect to Pulsar", it) }
    }
 }


### PR DESCRIPTION
## Summary
\`client.clusters().getClusters()\` can succeed and return an empty list when the broker is reachable but no clusters are configured. The previous code threw the return value away and unconditionally reported "Connected to Pulsar", masking a misconfigured broker.

## Test plan
- [ ] Existing tests pass
- [ ] Broker with no clusters reports unhealthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)