### PR TITLE
Distinguish socket timeout from generic failure in TcpHealthCheck

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/network/TcpHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/network/TcpHealthCheck.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.net.InetSocketAddress
 import java.net.Socket
+import java.net.SocketTimeoutException
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -22,15 +23,19 @@ class TcpHealthCheck(
          withContext(Dispatchers.IO) {
             Socket().use { socket ->
                val start = System.currentTimeMillis()
+               // Socket.connect either returns successfully (isConnected == true) or throws.
+               // SocketTimeoutException is the specific failure for connectionTimeout expiring;
+               // distinguish it so operators see "timed out" instead of a generic "failed".
                socket.connect(InetSocketAddress(host, port), connectionTimeout.inWholeMilliseconds.toInt())
                val time = (System.currentTimeMillis() - start).milliseconds
-               if (socket.isConnected) {
-                  HealthCheckResult.healthy("Connected to $host:$port after ${time.inWholeMilliseconds}ms")
-               } else {
-                  HealthCheckResult.unhealthy("Connection to $host:$port timed out after $connectionTimeout", null)
-               }
+               HealthCheckResult.healthy("Connected to $host:$port after ${time.inWholeMilliseconds}ms")
             }
          }
-      }.getOrElse { HealthCheckResult.unhealthy("Connection to $host:$port failed", it) }
+      }.getOrElse { t ->
+         if (t is SocketTimeoutException)
+            HealthCheckResult.unhealthy("Connection to $host:$port timed out after $connectionTimeout", t)
+         else
+            HealthCheckResult.unhealthy("Connection to $host:$port failed", t)
+      }
    }
 }


### PR DESCRIPTION
## Summary
- \`Socket.connect()\` either succeeds (\`isConnected == true\`) or throws — the \`isConnected\` else-branch was dead code.
- A real connect timeout fires \`SocketTimeoutException\`, which was swallowed into the generic "Connection failed" message, losing the distinct timeout signal.

Catch \`SocketTimeoutException\` explicitly and emit a "timed out" message.

## Test plan
- [ ] Existing tests pass
- [ ] Connect to a deny-filtered host: message says "timed out"

🤖 Generated with [Claude Code](https://claude.com/claude-code)