### PR TITLE
Add missing override val name to StartedThreadsHealthCheck

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/threads/StartedThreadsHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/threads/StartedThreadsHealthCheck.kt
@@ -17,6 +17,8 @@ class StartedThreadsHealthCheck(
   private val threadMXBean: ThreadMXBean = ManagementFactory.getThreadMXBean(),
 ) : HealthCheck {
 
+  override val name: String = "started_threads"
+
   override suspend fun check(): HealthCheckResult {
     val count = threadMXBean.totalStartedThreadCount
     return if (count <= maxStartedThreads) {


### PR DESCRIPTION
Every sibling thread check in this package declares a stable snake_case `name`. `StartedThreadsHealthCheck` was missing one, so the default fully-qualified-class-name was used — inconsistent with siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)