### PR TITLE
Distinguish check timeout from generic failure and propagate cancellation

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
@@ -194,6 +194,17 @@ class HealthCheckRegistry(
             HealthStatus.Healthy -> success(name, result)
             HealthStatus.Unhealthy -> failure(name, result)
          }
+      } catch (timeout: TimeoutCancellationException) {
+         // Distinguish a checkTimeout firing from a generic exception so operators see a
+         // clear "timed out after Xs" message instead of "failed due to TimeoutCancellationException".
+         val result = HealthCheckResult.unhealthy("$name timed out after $checkTimeout", timeout)
+         notifySubscribers(name, check, result)
+         notifyListeners(name, result)
+         failure(name, result)
+      } catch (cancel: CancellationException) {
+         // The enclosing scope was cancelled (e.g. registry.close()). Don't convert this into
+         // a fake "unhealthy" status — propagate so structured concurrency works correctly.
+         throw cancel
       } catch (t: Throwable) {
          val result = HealthCheckResult.unhealthy("$name failed due to ${t.javaClass.name}", t)
          notifySubscribers(name, check, result)


### PR DESCRIPTION
## Summary
\`HealthCheckRegistry.run\` had a single \`catch (t: Throwable)\`:
- A fired \`checkTimeout\` produced the unhelpful message \`"\$name failed due to kotlinx.coroutines.TimeoutCancellationException"\`.
- \`CancellationException\` (parent scope cancelled, e.g. \`registry.close()\`) was swallowed and converted into a fake unhealthy status, breaking structured concurrency.

Catch \`TimeoutCancellationException\` explicitly with a clear "timed out after X" message, and rethrow other \`CancellationException\`s.

## Test plan
- [ ] Existing tests pass
- [ ] Add test: slow check yields "timed out after \$checkTimeout" message
- [ ] \`registry.close()\` shuts down cleanly even when checks are in flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)