### PR TITLE
Make NamedThreadFactory thread counter per-instance

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/NamedThreadFactory.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/NamedThreadFactory.kt
@@ -3,9 +3,12 @@ package com.sksamuel.cohort
 import java.util.concurrent.ThreadFactory
 import java.util.concurrent.atomic.AtomicInteger
 
-private val counter = AtomicInteger(0)
-
 class NamedThreadFactory(val name: String, private val daemon: Boolean = false) : ThreadFactory {
+   // Per-instance counter so each factory numbers its threads from 0. The previous file-level
+   // counter was shared across every NamedThreadFactory in the JVM, producing non-contiguous
+   // thread names per factory (e.g. "scheduler-0", "scheduler-3", ...).
+   private val counter = AtomicInteger(0)
+
    override fun newThread(r: Runnable): Thread {
       val t = Thread(r, name + "-" + counter.getAndIncrement())
       t.isDaemon = daemon


### PR DESCRIPTION
The counter was declared at file scope so every `NamedThreadFactory` in the JVM shared a single `AtomicInteger` — two factories with different names produced non-contiguous numbering (`scheduler-0`, `scheduler-3`, ...). Cosmetic, but a trap for anyone counting threads by name. Move inside the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)