### PR TITLE
Make /threaddump output readable: StringBuilder + line separator

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/threads/dump.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/threads/dump.kt
@@ -2,11 +2,13 @@ package com.sksamuel.cohort.threads
 
 import java.lang.management.ManagementFactory
 
-fun getThreadDump() = runCatching {
-  val threadDump = StringBuffer(System.lineSeparator())
+fun getThreadDump(): Result<String> = runCatching {
+  // Use StringBuilder (unsynchronized) and append a line separator between threads so the
+  // dump is readable; ThreadInfo.toString() does not include a trailing newline.
+  val threadDump = StringBuilder()
   val threadMXBean = ManagementFactory.getThreadMXBean()
   threadMXBean.dumpAllThreads(true, true).forEach { t ->
-    threadDump.append(t.toString())
+    threadDump.append(t.toString()).append(System.lineSeparator())
   }
   threadDump.toString()
 }


### PR DESCRIPTION
## Summary
- \`ThreadInfo.toString()\` does not include a trailing newline, so threads were running together with no boundary.
- Switch to an unsynchronized \`StringBuilder\` and append \`System.lineSeparator()\` between entries.
- Declare the return type explicitly.

## Test plan
- [ ] GET /cohort/threaddump on Ktor and Vert.x apps; output is readable with one thread per separator boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)