### PR TITLE
Fix typo 'o healthcheck' -> 'No healthcheck' in register kdoc

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
@@ -93,7 +93,7 @@ class HealthCheckRegistry(
     * for both initial delay and intervals.
     *
     * @param name the name is associated with the [check] in the output json. By supplying a custom
-    *             name, the same check can be registered multiple times. o healthcheck can be registered
+    *             name, the same check can be registered multiple times. No healthcheck can be registered
     *             more than once with a repeated name.
     */
    fun register(


### PR DESCRIPTION
Trivial typo: missing leading 'N' in 'No healthcheck can be registered'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)