### PR TITLE
Encode monitored state in ThreadStateHealthCheck name

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/threads/ThreadStateHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/threads/ThreadStateHealthCheck.kt
@@ -13,7 +13,11 @@ class ThreadStateHealthCheck(
   private val maxCount: Int
 ) : HealthCheck {
 
-  override val name: String = "thread_state"
+  // Encode the monitored state in the name so two checks (e.g. BLOCKED and WAITING) can be
+  // registered using the default register(check) overload. With a single "thread_state" name,
+  // HealthCheckRegistry.register threw "Check thread_state already registered" on the second
+  // registration, making the canonical use-case impossible without manually naming each check.
+  override val name: String = "thread_state_${state.name.lowercase()}"
 
   override suspend fun check(): HealthCheckResult {
     val count = Thread.getAllStackTraces().keys.count { it.state == state }


### PR DESCRIPTION
## Summary
\`ThreadStateHealthCheck.name\` was the literal \`"thread_state"\`, so two checks for different states couldn't both be registered via the default \`register(check)\` overload — the second registration threw \`"Check thread_state already registered"\`. Since each instance monitors exactly one state, include it in the name.

## Test plan
- [ ] Register \`ThreadStateHealthCheck(BLOCKED, ...)\` and \`ThreadStateHealthCheck(WAITING, ...)\` via \`register(check)\`; both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)