### PR TITLE
Avoid full stack-trace dump in ThreadStateHealthCheck

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/threads/ThreadStateHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/threads/ThreadStateHealthCheck.kt
@@ -16,7 +16,14 @@ class ThreadStateHealthCheck(
   override val name: String = "thread_state"
 
   override suspend fun check(): HealthCheckResult {
-    val count = Thread.getAllStackTraces().keys.count { it.state == state }
+    // Enumerate live threads without producing a full stack-trace snapshot. The previous
+    // Thread.getAllStackTraces() capture is expensive (it suspends each thread to build a
+    // StackTraceElement[]) and was wasted work — only Thread.state was needed.
+    var group = Thread.currentThread().threadGroup
+    while (group.parent != null) group = group.parent
+    val threads = arrayOfNulls<Thread>(group.activeCount() * 2)
+    val n = group.enumerate(threads, true)
+    val count = (0 until n).count { threads[it]?.state == state }
     return if (count <= maxCount) {
       HealthCheckResult.healthy("Thread count for state $state is below threshold [$count <= $maxCount]")
     } else {


### PR DESCRIPTION
## Summary
\`Thread.getAllStackTraces()\` suspends every thread to build a \`StackTraceElement[]\` snapshot just so the check could read \`Thread.state\`. The cost is real on busy apps and the check runs on a short interval. Enumerate threads via the root ThreadGroup instead.

## Test plan
- [ ] Existing tests pass
- [ ] On an app with hundreds of threads, check latency drops materially

🤖 Generated with [Claude Code](https://claude.com/claude-code)