### PR TITLE
Delete partial heap dump if dumpHeap itself fails

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/heap/Heapdump.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/heap/Heapdump.kt
@@ -16,8 +16,11 @@ fun getHeapDump(): Result<ByteArray> = runCatching {
   // dumpHeap throws if the target already exists, so use a UUID rather than currentTimeMillis
   // (two calls in the same millisecond would otherwise collide).
   val path = tmpDir.resolve("heapdump-${UUID.randomUUID()}.hprof")
-  mxBean.dumpHeap(path.toString(), true)
+  // Cover dumpHeap with the same try/finally as the read; if dumpHeap partially writes the
+  // file and then throws (disk full, IOException, JMX issue) the temp file would otherwise
+  // be left behind on every failed call.
   try {
+    mxBean.dumpHeap(path.toString(), true)
     Files.readAllBytes(path)
   } finally {
     path.deleteIfExists()


### PR DESCRIPTION
`dumpHeap` was called outside the try/finally. A partial write followed by an exception (disk full, JMX failure) left the file on disk on every failure — eventually filling /tmp. Cover the call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)