### PR TITLE
Correct misleading Hikari testOnBorrow/testOnCreate in /datasources

### DIFF
--- a/cohort-hikari/src/main/kotlin/com/sksamuel/cohort/hikari/manager.kt
+++ b/cohort-hikari/src/main/kotlin/com/sksamuel/cohort/hikari/manager.kt
@@ -30,9 +30,16 @@ class HikariDataSourceManager(private val ds: HikariDataSource) : DataSourceMana
         maximumIdle = -1,
         minIdle = ds.minimumIdle,
         maxOpenPreparedStatements = -1,
-        testOnBorrow = ds.connectionTestQuery != null,
+        // Hikari always tests on borrow (uses JDBC4 isValid by default; connectionTestQuery
+        // is only a legacy fallback string). Deriving testOnBorrow from connectionTestQuery
+        // therefore reported `false` for the vast majority of Hikari pools even though every
+        // borrow is validated.
+        testOnBorrow = true,
         testOnReturn = null,
-        testOnCreate = ds.connectionInitSql != null,
+        // Hikari has no test-on-create concept. connectionInitSql is one-off initialization
+        // SQL run when a new connection is created — not a test. Reporting testOnCreate=true
+        // when only an init statement was configured was simply misleading.
+        testOnCreate = null,
       )
     }
   }


### PR DESCRIPTION
## Summary
- \`testOnBorrow = ds.connectionTestQuery != null\` was wrong: Hikari **always** tests on borrow (uses JDBC4 \`isValid()\`). \`connectionTestQuery\` is only a legacy fallback string for non-JDBC4 drivers, so the field reported false for almost every Hikari pool even though every borrow was being validated.
- \`testOnCreate = ds.connectionInitSql != null\` conflated a one-off init statement with a test that doesn't exist in Hikari.

Report \`testOnBorrow = true\` and \`testOnCreate = null\`.

## Test plan
- [ ] Existing tests pass
- [ ] /cohort/datasources output reflects real Hikari semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)