### PR TITLE
Convert createClient/shutdown failures to Unhealthy in DynamoDB check

### DIFF
--- a/cohort-aws-dynamo/src/main/kotlin/com/sksamuel/cohort/aws/dynamo/DynamoDBHealthCheck.kt
+++ b/cohort-aws-dynamo/src/main/kotlin/com/sksamuel/cohort/aws/dynamo/DynamoDBHealthCheck.kt
@@ -18,18 +18,26 @@ class DynamoDBHealthCheck(
 
    private fun <T> AmazonDynamoDB.use(f: (AmazonDynamoDB) -> T): Result<T> {
       val result = runCatching { f(this) }
-      this.shutdown()
+      runCatching { this.shutdown() }
       return result
    }
 
    override suspend fun check(): HealthCheckResult {
-      return runInterruptible(Dispatchers.IO) {
-         createClient().use {
-            it.listTables(1)
+      // Catch errors from createClient() itself (AWS region/credential resolution can throw
+      // synchronously on builder().build()). Previously such failures escaped runInterruptible
+      // and propagated out of check() instead of producing an Unhealthy result.
+      return runCatching {
+         runInterruptible(Dispatchers.IO) {
+            createClient().use {
+               it.listTables(1)
+            }
          }
       }.fold(
-         { HealthCheckResult.healthy("DynamoDB access successful") },
-         { HealthCheckResult.unhealthy("Could not connect to DynamoDB", it) }
+         { it.fold(
+            { HealthCheckResult.healthy("DynamoDB access successful") },
+            { HealthCheckResult.unhealthy("Could not connect to DynamoDB", it) }
+         )},
+         { HealthCheckResult.unhealthy("Could not connect to DynamoDB", it) },
       )
    }
 }


### PR DESCRIPTION
## Summary
- \`createClient()\` is user-supplied; AWS region/credential resolution can throw synchronously from \`builder().build()\`. That exception escaped \`runInterruptible\` and \`check()\`, so the registry saw a raw exception instead of an Unhealthy result.
- \`shutdown()\` ran unguarded — a throw there masked the original check failure.

Wrap the whole \`runInterruptible\` in \`runCatching\` and guard the shutdown.

## Test plan
- [ ] Existing tests pass
- [ ] Misconfigured AWS region: check produces Unhealthy(\"Could not connect to DynamoDB\")

🤖 Generated with [Claude Code](https://claude.com/claude-code)