### PR TITLE
Take HttpClient externally in Ktor EndpointHealthCheck (BREAKING)

### DIFF
--- a/cohort-ktor/src/main/kotlin/com/sksamuel/cohort/healthcheck/http/EndpointHealthCheck.kt
+++ b/cohort-ktor/src/main/kotlin/com/sksamuel/cohort/healthcheck/http/EndpointHealthCheck.kt
@@ -3,22 +3,22 @@ package com.sksamuel.cohort.healthcheck.http
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.apache5.Apache5
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.isSuccess
 
 /**
- * Executes a custom http request using a Ktor [Apache5] client.
+ * Executes a custom http request using a caller-supplied Ktor [HttpClient].
+ *
+ * The [HttpClient] is owned by the caller — its lifecycle (connection pool, engine threads) is
+ * the caller's responsibility. This mirrors [EndpointStartupHealthCheck], which has always
+ * accepted the client externally.
  */
 class EndpointHealthCheck(
+   private val client: HttpClient,
    private val eval: suspend (HttpResponse) -> Boolean = { it.status.isSuccess() },
    override val name: String = "endpoint_request",
    private val fn: suspend (HttpClient) -> HttpResponse,
 ) : HealthCheck {
-
-   private val client = HttpClient(Apache5) {
-      expectSuccess = false
-   }
 
    override suspend fun check(): HealthCheckResult {
       val resp = fn(client)

--- a/cohort-ktor/src/test/kotlin/com/sksamuel/cohort/healthcheck/http/EndpointHealthCheckTest.kt
+++ b/cohort-ktor/src/test/kotlin/com/sksamuel/cohort/healthcheck/http/EndpointHealthCheckTest.kt
@@ -3,6 +3,8 @@ package com.sksamuel.cohort.healthcheck.http
 import com.sksamuel.cohort.HealthStatus
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.apache5.Apache5
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
@@ -24,17 +26,22 @@ class EndpointHealthCheckTest : FunSpec() {
       }
       server.start(false)
 
-      afterSpec { server.stop() }
+      val httpClient = HttpClient(Apache5) { expectSuccess = false }
+
+      afterSpec {
+         server.stop()
+         httpClient.close()
+      }
 
       test("testing fail") {
-         val check = EndpointHealthCheck { client ->
+         val check = EndpointHealthCheck(httpClient) { client ->
             client.get("http://localhost:1234/bar")
          }
          check.check().status shouldBe HealthStatus.Unhealthy
       }
 
       test("testing success") {
-         val check = EndpointHealthCheck { client ->
+         val check = EndpointHealthCheck(httpClient) { client ->
             client.get("http://localhost:1234/foo")
          }
          check.check().status shouldBe HealthStatus.Healthy


### PR DESCRIPTION
## Summary
**Breaking change.** \`EndpointHealthCheck\` created its own \`HttpClient(Apache5)\` and never closed it — each instance leaked engine threads and a connection pool. Take the client from the caller, mirroring \`EndpointStartupHealthCheck\` which has always done so.

Existing callers must now pass an \`HttpClient\`. Test is updated.

## Test plan
- [ ] Existing tests pass
- [ ] Engine threads can be released on shutdown via the caller's \`HttpClient.close()\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)