### PR TITLE
Take HttpClient externally in Vertx Endpoint(Startup)HealthCheck (BREAKING)

### DIFF
--- a/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/healthcheck/http/EndpointHealthCheck.kt
+++ b/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/healthcheck/http/EndpointHealthCheck.kt
@@ -2,23 +2,22 @@ package com.sksamuel.cohort.healthcheck.http
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
-import io.vertx.core.Vertx
 import io.vertx.core.http.HttpClient
 import io.vertx.core.http.HttpClientResponse
 
 /**
- * Executes a custom http request using a Vertx HTTP client.
- * The result is considered healthy if [eval] returns true, which by default looks for a 2xx status code.
+ * Executes a custom http request using a caller-supplied Vertx [HttpClient].
+ *
+ * The [HttpClient] is owned by the caller — its lifecycle (connection pool, netty event loops)
+ * is the caller's responsibility. Previously this class created its own client via
+ * `vertx.createHttpClient()` and never closed it, leaking pooled connections per instance.
  */
 class EndpointHealthCheck(
-   vertx: Vertx,
+   private val client: HttpClient,
    private val eval: suspend (HttpClientResponse) -> Boolean = { it.statusCode() in 200..299 },
    override val name: String = "endpoint_request",
    private val fn: suspend (HttpClient) -> HttpClientResponse,
 ) : HealthCheck {
-
-
-   private val client = vertx.createHttpClient()
 
    override suspend fun check(): HealthCheckResult {
       val resp = fn(client)

--- a/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/healthcheck/http/EndpointStartupHealthCheck.kt
+++ b/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/healthcheck/http/EndpointStartupHealthCheck.kt
@@ -2,7 +2,6 @@ package com.sksamuel.cohort.healthcheck.http
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
-import io.vertx.core.Vertx
 import io.vertx.core.http.HttpClient
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -15,15 +14,17 @@ import java.util.concurrent.atomic.AtomicBoolean
  *
  * It does not continually ping a service, to avoid an upstream service going down, and bringing
  * down all the dependent services with it in a cascading fashion.
+ *
+ * The supplied [client] is owned by the caller. Previously this class created its own client
+ * via `vertx.createHttpClient()` and never closed it.
  */
 class EndpointStartupHealthCheck(
-   vertx: Vertx,
+   private val client: HttpClient,
    override val name: String = "endpoint_startup_request",
    private val fn: suspend (HttpClient) -> Boolean,
 ) : HealthCheck {
 
    private val successful = AtomicBoolean(false)
-   private val client = vertx.createHttpClient()
 
    override suspend fun check(): HealthCheckResult {
       return if (successful.get()) {


### PR DESCRIPTION
## Summary
**Breaking change.** Both Vertx endpoint checks created their own \`HttpClient\` and never closed it. Take the client from the caller, who now owns the lifecycle. Mirrors the same change made on the Ktor side.

## Test plan
- [ ] Existing tests pass
- [ ] Callers can share a single HttpClient and close it on shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)