### PR TITLE
Key CohortMetrics counter cache by MeterRegistry; snapshot tags

### DIFF
--- a/cohort-micrometer/src/main/kotlin/com/sksamuel/cohort/micrometer/CohortMetrics.kt
+++ b/cohort-micrometer/src/main/kotlin/com/sksamuel/cohort/micrometer/CohortMetrics.kt
@@ -7,11 +7,16 @@ import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Tag
 import io.micrometer.core.instrument.binder.MeterBinder
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArraySet
 
 class CohortMetrics(private val healthCheckRegistry: HealthCheckRegistry) : MeterBinder {
 
-   private val counters = ConcurrentHashMap<Pair<String, HealthStatus>, Counter>()
-   private val tags = mutableSetOf<Tag>()
+   // Key includes the MeterRegistry so a single CohortMetrics bound to two different
+   // registries doesn't reuse the first registry's Counter for the second. Without the
+   // registry in the key, computeIfAbsent saw an existing counter (registered against the
+   // first registry) and skipped registration in the second.
+   private val counters = ConcurrentHashMap<Triple<MeterRegistry, String, HealthStatus>, Counter>()
+   private val tags = CopyOnWriteArraySet<Tag>()
 
    /**
     * Adds the given tags to the metrics.
@@ -21,13 +26,16 @@ class CohortMetrics(private val healthCheckRegistry: HealthCheckRegistry) : Mete
    }
 
    override fun bindTo(registry: MeterRegistry) {
+      // Snapshot tags at bind-time so a later tags(...) call from another thread can't race
+      // with the subscriber iterating the set.
+      val snapshot = tags.toList()
       healthCheckRegistry.addSubscriber { name, check, result ->
-         val counter = counters.computeIfAbsent(Pair(name, result.status)) {
+         val counter = counters.computeIfAbsent(Triple(registry, name, result.status)) {
             Counter.builder("cohort.healthcheck")
                .tag("name", name)
                .tag("type", check::class.java.name)
                .tag("status", result.status.name)
-               .tags(tags)
+               .tags(snapshot)
                .register(registry)
          }
          counter.increment()


### PR DESCRIPTION
## Summary
1. The counter cache was keyed by \`(name, status)\` only. Binding to two registries shared the cached counter from the first — the second registry silently received nothing.
2. \`tags\` was a non-synchronized \`mutableSetOf<Tag>\` mutated by \`tags(...)\` and read inside the subscriber on health-check event threads — \`ConcurrentModificationException\` waiting to happen.

Key the cache by \`(registry, name, status)\` and snapshot tags at bind-time. Back the tag set with \`CopyOnWriteArraySet\`.

## Test plan
- [ ] Existing micrometer tests pass
- [ ] Binding to two registries records counters in both

🤖 Generated with [Claude Code](https://claude.com/claude-code)