### PR TITLE
Redact sensitive system property values in /cohort/sysprops

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/sysprops.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/system/sysprops.kt
@@ -1,7 +1,26 @@
 package com.sksamuel.cohort.system
 
+// Keys whose value should be redacted when exposed via the /cohort/sysprops endpoint.
+// System properties commonly carry credentials passed via -D flags (e.g.
+// -Djavax.net.ssl.keyStorePassword=..., -Daws.secretAccessKey=..., custom -Dapi.token=...).
+// Without redaction, /cohort/sysprops leaks them to anyone with access to the endpoint.
+private val SENSITIVE_KEY_PATTERNS = listOf(
+  "password", "passwd", "secret", "token", "credential", "apikey", "api_key", "private",
+)
+
+private fun isSensitive(key: String): Boolean {
+  val lower = key.lowercase()
+  return SENSITIVE_KEY_PATTERNS.any { lower.contains(it) }
+}
+
 fun getSysProps(): Result<SysProps> = runCatching {
-  val map = System.getProperties().map { it.key.toString() to it.value.toString() }.toMap()
+  val map = System.getProperties()
+    .map { (k, v) ->
+      val key = k.toString()
+      val value = if (isSensitive(key)) "***REDACTED***" else v.toString()
+      key to value
+    }
+    .toMap()
   SysProps(map)
 }
 


### PR DESCRIPTION
## Summary
\`/cohort/sysprops\` dumped every system property verbatim. System properties commonly carry secrets passed via \`-D\` flags (\`javax.net.ssl.keyStorePassword\`, \`aws.secretAccessKey\`, custom \`api.token\`, etc.) so the endpoint leaked credentials to anyone with access.

Redact values whose key matches a built-in sensitive-key heuristic (password/secret/token/credential/apikey/private). Conservative by default.

## Test plan
- [ ] Existing tests pass
- [ ] /cohort/sysprops on a JVM with \`-Dapi.token=hunter2\` shows \`***REDACTED***\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)