### PR TITLE
Handle null ClusterHealthStatus distinctly in ElasticClusterHealthCheck

### DIFF
--- a/cohort-elastic/src/main/kotlin/com/sksamuel/cohort/elastic/ElasticClusterHealthCheck.kt
+++ b/cohort-elastic/src/main/kotlin/com/sksamuel/cohort/elastic/ElasticClusterHealthCheck.kt
@@ -1,5 +1,3 @@
-@file:Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
-
 package com.sksamuel.cohort.elastic
 
 import com.sksamuel.cohort.HealthCheck
@@ -30,7 +28,13 @@ class ElasticClusterHealthCheck(
         client.cluster().health(ClusterHealthRequest(), RequestOptions.DEFAULT)
       }
 
-      val status = health.status
+      // Treat `health.status` as a platform-nullable enum. The previous file-level
+      // @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA") silenced a real concern: a Java-returned
+      // null would crash `${status.name}` with NPE, get caught by the outer runCatching, and
+      // be reported as "Error connecting to elastic" — misleading, since the connection
+      // succeeded. Handle null explicitly.
+      val status: ClusterHealthStatus? = health.status
+      if (status == null) return@runCatching HealthCheckResult.unhealthy("Elastic cluster returned no status", null)
       val msg = "Elastic cluster is ${status.name}"
       when (status) {
         ClusterHealthStatus.RED -> HealthCheckResult.unhealthy(msg, null)


### PR DESCRIPTION
## Summary
\`@file:Suppress(\"WHEN_ENUM_CAN_BE_NULL_IN_JAVA\")\` silenced a real concern: \`health.status\` is a Java platform type that can be null. A null status would NPE through \`status.name\`, be caught by the outer \`runCatching\`, and be misreported as "Error connecting to elastic" — even though the connection succeeded. Drop the suppression and handle null explicitly.

## Test plan
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)