### PR TITLE
Clarify FreememHealthCheck KDoc boundary semantics

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/FreememHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/FreememHealthCheck.kt
@@ -8,7 +8,7 @@ import java.lang.management.MemoryPoolMXBean
 /**
  * A Cohort [HealthCheck] that checks free memory in the system.
  *
- * The check is considered healthy if the amount of free memory is above [minFreeBytes].
+ * The check is considered healthy if the amount of free memory is at or above [minFreeBytes].
  */
 class FreememHealthCheck(private val minFreeBytes: Long) : HealthCheck {
 


### PR DESCRIPTION
Trivial KDoc fix: code is `>= minFreeBytes` → healthy; the KDoc previously said "above" implying strict `>`. Updated to "at or above".

🤖 Generated with [Claude Code](https://claude.com/claude-code)