### PR TITLE
Propagate CancellationException from Lettuce health checks

### DIFF
--- a/cohort-lettuce/src/main/kotlin/com/sksamuel/cohort/lettuce/RedisClusterHealthCheck.kt
+++ b/cohort-lettuce/src/main/kotlin/com/sksamuel/cohort/lettuce/RedisClusterHealthCheck.kt
@@ -3,6 +3,7 @@ package com.sksamuel.cohort.lettuce
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.future.await
 import kotlin.random.Random
 
@@ -40,9 +41,15 @@ class RedisClusterHealthCheck<K, V>(
    }
 
    override suspend fun check(): HealthCheckResult {
-      return runCatching {
+      return try {
          command(conn)
          HealthCheckResult.healthy("Redis command successful")
-      }.getOrElse { HealthCheckResult.unhealthy("Redis command failure", it) }
+      } catch (c: CancellationException) {
+         // Don't convert parent-scope cancellation (e.g. registry shutdown / checkTimeout) into
+         // a fake "Redis command failure". Let it propagate so structured concurrency works.
+         throw c
+      } catch (t: Throwable) {
+         HealthCheckResult.unhealthy("Redis command failure", t)
+      }
    }
 }

--- a/cohort-lettuce/src/main/kotlin/com/sksamuel/cohort/lettuce/RedisHealthCheck.kt
+++ b/cohort-lettuce/src/main/kotlin/com/sksamuel/cohort/lettuce/RedisHealthCheck.kt
@@ -3,6 +3,7 @@ package com.sksamuel.cohort.lettuce
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
 import io.lettuce.core.api.StatefulRedisConnection
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.future.await
 import kotlin.random.Random
 
@@ -37,9 +38,15 @@ class RedisHealthCheck<K, V>(
    }
 
    override suspend fun check(): HealthCheckResult {
-      return runCatching {
+      return try {
          command(conn)
          HealthCheckResult.healthy("Redis command successful")
-      }.getOrElse { HealthCheckResult.unhealthy("Redis command failure", it) }
+      } catch (c: CancellationException) {
+         // Don't convert parent-scope cancellation (e.g. registry shutdown / checkTimeout) into
+         // a fake "Redis command failure". Let it propagate so structured concurrency works.
+         throw c
+      } catch (t: Throwable) {
+         HealthCheckResult.unhealthy("Redis command failure", t)
+      }
    }
 }


### PR DESCRIPTION
## Summary
\`runCatching { ... }.getOrElse { unhealthy(...) }\` swallowed \`CancellationException\` (and \`TimeoutCancellationException\` from the registry's \`withTimeout\`), turning cancellation into a fake "Redis command failure" — losing the timeout message and breaking structured concurrency. Rethrow CancellationException explicitly.

## Test plan
- [ ] Existing tests pass
- [ ] Registry shutdown / checkTimeout now reports timeout properly instead of generic Redis failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)