### PR TITLE
Distinguish empty metadata from no UP nodes in CassandraDriverHealthCheck

### DIFF
--- a/cohort-cassandra/src/main/kotlin/com/sksamuel/cohort/cassandra/CassandraDriverHealthCheck.kt
+++ b/cohort-cassandra/src/main/kotlin/com/sksamuel/cohort/cassandra/CassandraDriverHealthCheck.kt
@@ -11,12 +11,19 @@ class CassandraDriverHealthCheck(
 ) : HealthCheck {
 
    override suspend fun check(): HealthCheckResult =
-      runCatching {
-         session.metadata.nodes.values.any { node -> node.state == NodeState.UP }
-      }.fold(
-         onSuccess = { anyUp ->
-            if (anyUp) HealthCheckResult.healthy("Cassandra access successful")
-            else HealthCheckResult.unhealthy("Could not access Cassandra")
+      runCatching { session.metadata.nodes.values }.fold(
+         onSuccess = { nodes ->
+            // Distinguish three cases:
+            //  - no metadata yet (startup race / metadata reset) — the driver hasn't received
+            //    the topology yet; reporting "could not access" misleads operators into
+            //    debugging connectivity. Surface a distinct message.
+            //  - no UP nodes (real outage)
+            //  - at least one UP node (healthy)
+            when {
+               nodes.isEmpty() -> HealthCheckResult.unhealthy("Cassandra node metadata not yet available")
+               nodes.any { it.state == NodeState.UP } -> HealthCheckResult.healthy("Cassandra access successful")
+               else -> HealthCheckResult.unhealthy("No Cassandra nodes are UP")
+            }
          },
          onFailure = { error ->
             HealthCheckResult.unhealthy("Could not access Cassandra", error)


### PR DESCRIPTION
Empty `session.metadata.nodes` (driver hasn't received topology yet) was being reported as "Could not access Cassandra", misleading operators into debugging connectivity. Split into three states: empty metadata, no-UP-nodes, at-least-one-UP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)