### PR TITLE
Register JavaTimeModule in cohort-vertx json mapper

### DIFF
--- a/cohort-vertx/build.gradle.kts
+++ b/cohort-vertx/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
    implementation(projects.cohortApi)
    implementation(libs.jackson.module.kotlin)
+   implementation(libs.jackson.datatype.jsr310)
    api(libs.vertx.core)
    api(libs.vertx.coroutines)
    api(libs.vertx.kotlin)

--- a/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/json.kt
+++ b/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/json.kt
@@ -1,5 +1,7 @@
 package com.sksamuel.cohort.vertx
 
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.sksamuel.cohort.HealthStatus
 import com.sksamuel.cohort.db.DataSourceInfo
@@ -37,4 +39,10 @@ fun SysProps.toJson(): String = mapper.writeValueAsString(this)
 fun GCInfo.toJson(): String = mapper.writeValueAsString(this)
 fun MemoryInfo.toJson(): String = mapper.writeValueAsString(this)
 
+// Register JavaTimeModule and disable WRITE_DATES_AS_TIMESTAMPS so any caller serializing the
+// data classes that contain java.time types (e.g. Instant inside Migration) gets ISO-8601
+// strings instead of a Jackson failure or numeric timestamps. The sibling cohort-ktor
+// `endpoints/json.kt` already does this — keep them aligned.
 val mapper = jacksonObjectMapper()
+   .registerModule(JavaTimeModule())
+   .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)


### PR DESCRIPTION
The cohort-vertx `json.kt` mapper was bare `jacksonObjectMapper()`. The cohort-ktor sibling registers `JavaTimeModule` + `disable(WRITE_DATES_AS_TIMESTAMPS)`. Harmonize so calling `.toJson()` on any data class with `java.time` types produces ISO-8601 strings consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)