### PR TITLE
Redact sensitive values in /cohort/jvm vmOptions

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/jvm/JvmOptions.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/jvm/JvmOptions.kt
@@ -2,12 +2,45 @@ package com.sksamuel.cohort.jvm
 
 import java.lang.management.ManagementFactory
 
+// JVM args commonly carry secrets passed via `-D` flags
+// (`-Djavax.net.ssl.keyStorePassword=...`, `-Daws.secretAccessKey=...`, custom `-Dapi.token=...`)
+// or via `-javaagent` license/key params. Without redaction `/cohort/jvm` leaks them.
+// Mirrors the sysprops redaction added previously.
+private val SENSITIVE_PATTERNS = listOf(
+  "password", "passwd", "secret", "token", "credential", "apikey", "api_key", "private",
+  "license_key", "license-key",
+)
+
+private fun isSensitive(s: String): Boolean {
+  val lower = s.lowercase()
+  return SENSITIVE_PATTERNS.any { lower.contains(it) }
+}
+
+internal fun redactVmArg(arg: String): String {
+  // Redact -DkeyName=value when the key matches the heuristic.
+  if (arg.startsWith("-D")) {
+    val eq = arg.indexOf('=')
+    if (eq > 2) {
+      val key = arg.substring(2, eq)
+      if (isSensitive(key)) return "${arg.substring(0, eq + 1)}***REDACTED***"
+    }
+  }
+  // Redact `-javaagent:.../foo.jar=license_key=...` style args.
+  if (isSensitive(arg)) {
+    // Best-effort: keep everything before the first '=' so the arg shape stays visible.
+    val eq = arg.indexOf('=')
+    if (eq > 0) return "${arg.substring(0, eq + 1)}***REDACTED***"
+    return "***REDACTED***"
+  }
+  return arg
+}
+
 fun getJvmDetails(): Result<Jvm> = runCatching {
   val bean = ManagementFactory.getRuntimeMXBean()
   Jvm(
     name = bean.name,
     pid = bean.pid,
-    vmOptions = bean.inputArguments,
+    vmOptions = bean.inputArguments.map(::redactVmArg),
     classPath = bean.classPath,
     specName = bean.specName,
     specVendor = bean.specVendor,


### PR DESCRIPTION
JVM launch args carry secrets via `-D` flags or `-javaagent` license params. `/cohort/jvm` exposed them all. Apply the same redaction heuristic used for sysprops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)