### PR TITLE
Report empty HealthCheckRegistry as unhealthy, not vacuously healthy

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
@@ -238,7 +238,11 @@ class HealthCheckRegistry(
     * A service is considered healthy if all the healthchecks are in healthy state.
     */
    fun status(): ServiceHealth {
-      val healthy = statuses.values.all { it.result.isHealthy }
+      // Iterable.all { } returns true on an empty collection. Without an isNotEmpty() guard, a
+      // registry with no health checks (or one whose statuses were never populated because
+      // startUnhealthy = false and no checks have run yet) reports the service as healthy with
+      // an empty payload — a silent green liveness probe with no underlying signal.
+      val healthy = statuses.isNotEmpty() && statuses.values.all { it.result.isHealthy }
       return ServiceHealth(healthy, statuses.toMap())
    }
 


### PR DESCRIPTION
`statuses.values.all{}` returns true on empty. A registry with no checks (or one before any check has run with `startUnhealthy=false`) reported healthy with an empty payload — a silent green probe with no underlying signal. Require non-empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)