### PR TITLE
Set text/plain Content-Type on Vertx non-verbose healthcheck response

### DIFF
--- a/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
+++ b/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
@@ -204,7 +204,11 @@ fun Router.cohort(cohort: CohortConfiguration) {
                }
                context.json(results)
             } else {
-               context.response().end(httpStatus.reasonPhrase())
+               // Set an explicit Content-Type — without one, Vert.x emits no header at all,
+               // which trips proxies and clients that sniff. Mirrors the Ktor sibling fix.
+               context.response()
+                  .putHeader("Content-Type", "text/plain")
+                  .end(httpStatus.reasonPhrase())
             }
          }
    }


### PR DESCRIPTION
Mirrors the Ktor fix: when `verboseHealthCheckResponse=false` the Vert.x handler wrote the HTTP reason phrase with no Content-Type. Set `text/plain`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)