### PR TITLE
Add missing override val name to HotSpotCompilationTimeHealthCheck

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/cpu/HotSpotCompilationTimeHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/cpu/HotSpotCompilationTimeHealthCheck.kt
@@ -12,6 +12,8 @@ import java.lang.management.ManagementFactory
  * 2000 is a fair value for most smaller microservices.
  */
 class HotSpotCompilationTimeHealthCheck(private val time: Long = 2000) : HealthCheck {
+   override val name: String = "hotspot_compilation_time"
+
    override suspend fun check(): HealthCheckResult {
       val compilationTime = ManagementFactory.getCompilationMXBean().totalCompilationTime
       return if (compilationTime >= time)


### PR DESCRIPTION
Sibling checks declare stable snake_case names. This one defaulted to the fully-qualified class name. Add `hotspot_compilation_time`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)