### PR TITLE
Fix ProcessCpuHealthCheck KDoc — was copy-pasted from SystemCpu

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/cpu/ProcessCpuHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/cpu/ProcessCpuHealthCheck.kt
@@ -6,10 +6,10 @@ import com.sun.management.OperatingSystemMXBean
 import java.lang.management.ManagementFactory
 
 /**
- * A Cohort [HealthCheck] that checks that the maximum system cpu is below a threshold.
+ * A Cohort [HealthCheck] that checks that the process cpu load is below a threshold.
  * Values are in the range 0 and 1.0.
  *
- * The check is considered healthy if the system cpu load is < [maxLoad].
+ * The check is considered healthy if the process cpu load is < [maxLoad].
  */
 class ProcessCpuHealthCheck(private val maxLoad: Double) : HealthCheck {
 


### PR DESCRIPTION
KDoc described 'system cpu' but the class reads `processCpuLoad`. Replace 'system' with 'process'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)