### PR TITLE
Propagate CancellationException from Kafka cluster/topic checks

### DIFF
--- a/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaClusterHealthCheck.kt
+++ b/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaClusterHealthCheck.kt
@@ -2,6 +2,7 @@ package com.sksamuel.cohort.kafka
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.future.await
 import org.apache.kafka.clients.admin.Admin
 
@@ -25,6 +26,10 @@ class KafkaClusterHealthCheck(
             controller == null -> HealthCheckResult.unhealthy("Kafka cluster returned without controller", null)
             else -> HealthCheckResult.healthy("Connected to kafka cluster with controller ${controller.host()} and ${nodes.size} node(s)")
          }
+      } catch (c: CancellationException) {
+         // Don't convert parent-scope cancellation (registry shutdown or checkTimeout) into
+         // a fake "could not connect" failure — let it propagate.
+         throw c
       } catch (t: Throwable) {
          HealthCheckResult.unhealthy("Could not connect to kafka cluster", t)
       }

--- a/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaTopicHealthCheck.kt
+++ b/cohort-kafka/src/main/kotlin/com/sksamuel/cohort/kafka/KafkaTopicHealthCheck.kt
@@ -2,6 +2,7 @@ package com.sksamuel.cohort.kafka
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.future.await
 import org.apache.kafka.clients.admin.Admin
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
@@ -26,6 +27,10 @@ class KafkaTopicHealthCheck(
          }
       } catch (e: UnknownTopicOrPartitionException) {
          HealthCheckResult.unhealthy("Topic $topic does not exist on kafka cluster", e)
+      } catch (c: CancellationException) {
+         // Don't convert parent-scope cancellation (registry shutdown or checkTimeout) into
+         // a fake "could not query" failure — let it propagate.
+         throw c
       } catch (t: Throwable) {
          HealthCheckResult.unhealthy("Could not query kafka cluster for topic $topic", t)
       }


### PR DESCRIPTION
Both Kafka checks' `catch (t: Throwable)` swallowed `CancellationException` / `TimeoutCancellationException` and reported them as generic Kafka failures. Rethrow cancellation explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)