### PR TITLE
Propagate CancellationException from Mongo/Rabbit/Elastic/Pulsar checks

### DIFF
--- a/cohort-elastic/src/main/kotlin/com/sksamuel/cohort/elastic/ElasticClusterCommandCheck.kt
+++ b/cohort-elastic/src/main/kotlin/com/sksamuel/cohort/elastic/ElasticClusterCommandCheck.kt
@@ -4,6 +4,7 @@ package com.sksamuel.cohort.elastic
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runInterruptible
 import org.elasticsearch.client.RestHighLevelClient
@@ -21,12 +22,15 @@ class ElasticClusterCommandCheck(
 ) : HealthCheck {
 
   override suspend fun check(): HealthCheckResult {
-    return runCatching {
+    return try {
       runInterruptible(Dispatchers.IO) {
         command(client)
       }
-    }.getOrElse {
-      HealthCheckResult.unhealthy("Error executing health check against elasticsearch", it)
+    } catch (c: CancellationException) {
+      // Let parent-scope cancellation propagate; runInterruptible may surface it.
+      throw c
+    } catch (t: Throwable) {
+      HealthCheckResult.unhealthy("Error executing health check against elasticsearch", t)
     }
   }
 }

--- a/cohort-mongo/src/main/kotlin/com/sksamuel/cohort/mongo/GenericMongoConnectionHealthCheck.kt
+++ b/cohort-mongo/src/main/kotlin/com/sksamuel/cohort/mongo/GenericMongoConnectionHealthCheck.kt
@@ -2,6 +2,8 @@ package com.sksamuel.cohort.mongo
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration.Companion.seconds
 
@@ -11,13 +13,18 @@ class GenericMongoConnectionHealthCheck(
 ) : HealthCheck {
 
   override suspend fun check(): HealthCheckResult {
-    return runCatching {
+    return try {
       withTimeout(5.seconds) {
-         val dbs = listDatabaseNames()
-         HealthCheckResult.healthy("Connected to mongo instance (${dbs.size} databases)")
+        val dbs = listDatabaseNames()
+        HealthCheckResult.healthy("Connected to mongo instance (${dbs.size} databases)")
       }
-    }.getOrElse {
-      HealthCheckResult.unhealthy("Could not connect to mongo instance", it)
+    } catch (t: TimeoutCancellationException) {
+      HealthCheckResult.unhealthy("Could not connect to mongo instance (timed out)", t)
+    } catch (c: CancellationException) {
+      // Let parent-scope cancellation (registry shutdown, etc.) propagate.
+      throw c
+    } catch (t: Throwable) {
+      HealthCheckResult.unhealthy("Could not connect to mongo instance", t)
     }
   }
 }

--- a/cohort-pulsar/src/main/kotlin/com/sksamuel/cohort/pulsar/PulsarHealthCheck.kt
+++ b/cohort-pulsar/src/main/kotlin/com/sksamuel/cohort/pulsar/PulsarHealthCheck.kt
@@ -2,6 +2,7 @@ package com.sksamuel.cohort.pulsar
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runInterruptible
 import org.apache.pulsar.client.admin.PulsarAdmin
@@ -20,11 +21,15 @@ class PulsarHealthCheck(
    }
 
    override suspend fun check(): HealthCheckResult {
-      return runCatching {
+      return try {
          runInterruptible(Dispatchers.IO) {
             client.clusters().getClusters()
          }
          HealthCheckResult.healthy("Connected to Pulsar")
-      }.getOrElse { HealthCheckResult.unhealthy("Could not connect to Pulsar", it) }
+      } catch (c: CancellationException) {
+         throw c
+      } catch (t: Throwable) {
+         HealthCheckResult.unhealthy("Could not connect to Pulsar", t)
+      }
    }
 }

--- a/cohort-rabbit/src/main/kotlin/com/sksamuel/cohort/rabbit/RabbitConnectionHealthCheck.kt
+++ b/cohort-rabbit/src/main/kotlin/com/sksamuel/cohort/rabbit/RabbitConnectionHealthCheck.kt
@@ -3,7 +3,9 @@ package com.sksamuel.cohort.rabbit
 import com.rabbitmq.client.ConnectionFactory
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration.Companion.seconds
@@ -14,7 +16,7 @@ class RabbitConnectionHealthCheck(
 ) : HealthCheck {
 
    override suspend fun check(): HealthCheckResult {
-      return runCatching {
+      return try {
          withTimeout(5.seconds) {
             runInterruptible(Dispatchers.IO) {
                factory.newConnection().use {
@@ -22,8 +24,12 @@ class RabbitConnectionHealthCheck(
                }
             }
          }
-      }.getOrElse {
-         HealthCheckResult.unhealthy("Could not connect to rabbit instance", it)
+      } catch (t: TimeoutCancellationException) {
+         HealthCheckResult.unhealthy("Could not connect to rabbit instance (timed out)", t)
+      } catch (c: CancellationException) {
+         throw c
+      } catch (t: Throwable) {
+         HealthCheckResult.unhealthy("Could not connect to rabbit instance", t)
       }
    }
 }

--- a/cohort-rabbit/src/main/kotlin/com/sksamuel/cohort/rabbit/RabbitQueueHealthCheck.kt
+++ b/cohort-rabbit/src/main/kotlin/com/sksamuel/cohort/rabbit/RabbitQueueHealthCheck.kt
@@ -3,7 +3,9 @@ package com.sksamuel.cohort.rabbit
 import com.rabbitmq.client.ConnectionFactory
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration.Companion.seconds
@@ -21,7 +23,7 @@ class RabbitQueueHealthCheck(
 ) : HealthCheck {
 
    override suspend fun check(): HealthCheckResult {
-      return runCatching {
+      return try {
          withTimeout(5.seconds) {
             runInterruptible(Dispatchers.IO) {
                factory.newConnection().use { conn ->
@@ -32,8 +34,12 @@ class RabbitQueueHealthCheck(
                }
             }
          }
-      }.getOrElse {
-         HealthCheckResult.unhealthy("Could not connect to RabbitMQ, or queue does not exist $queue", it)
+      } catch (t: TimeoutCancellationException) {
+         HealthCheckResult.unhealthy("Could not connect to RabbitMQ queue $queue (timed out)", t)
+      } catch (c: CancellationException) {
+         throw c
+      } catch (t: Throwable) {
+         HealthCheckResult.unhealthy("Could not connect to RabbitMQ, or queue does not exist $queue", t)
       }
    }
 }


### PR DESCRIPTION
Five health checks were swallowing CancellationException via `runCatching`. Switch to try/catch with explicit rethrow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)