### PR TITLE
Propagate Cancellation/Interrupt in jedis Redis health checks

### DIFF
--- a/cohort-jedis/src/main/kotlin/com/sksamuel/cohort/redis/RedisClusterHealthCheck.kt
+++ b/cohort-jedis/src/main/kotlin/com/sksamuel/cohort/redis/RedisClusterHealthCheck.kt
@@ -2,6 +2,7 @@ package com.sksamuel.cohort.redis
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runInterruptible
 import redis.clients.jedis.DefaultJedisClientConfig
@@ -52,10 +53,13 @@ class RedisClusterHealthCheck(
 
    override suspend fun check(): HealthCheckResult {
       return runInterruptible(Dispatchers.IO) {
-         runCatching {
+         try {
             command(jedis)
-         }.getOrElse {
-            HealthCheckResult.unhealthy("Could not connect to redis cluster", it)
+         } catch (c: CancellationException) {
+            throw c
+         } catch (t: Throwable) {
+            if (t is InterruptedException) Thread.currentThread().interrupt()
+            HealthCheckResult.unhealthy("Could not connect to redis cluster", t)
          }
       }
    }

--- a/cohort-jedis/src/main/kotlin/com/sksamuel/cohort/redis/RedisConnectionHealthCheck.kt
+++ b/cohort-jedis/src/main/kotlin/com/sksamuel/cohort/redis/RedisConnectionHealthCheck.kt
@@ -2,6 +2,7 @@ package com.sksamuel.cohort.redis
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runInterruptible
 import redis.clients.jedis.Connection
@@ -49,10 +50,17 @@ class RedisConnectionHealthCheck(
 
    override suspend fun check(): HealthCheckResult {
       return runInterruptible(Dispatchers.IO) {
-         runCatching {
+         try {
             command(jedis.connection)
-         }.getOrElse {
-            HealthCheckResult.unhealthy("Could not connect to Redis", it)
+         } catch (c: CancellationException) {
+            // runInterruptible converts thread interrupts to CancellationException. Don't
+            // swallow it into a "Could not connect to Redis" result — let cancellation flow.
+            throw c
+         } catch (t: Throwable) {
+            // InterruptedException surfaces here for non-coroutine interrupt paths; re-arm
+            // the interrupt flag so the caller can observe it.
+            if (t is InterruptedException) Thread.currentThread().interrupt()
+            HealthCheckResult.unhealthy("Could not connect to Redis", t)
          }
       }
    }


### PR DESCRIPTION
Both jedis health checks swallowed CancellationException via inner `runCatching`. Catch cancellation explicitly and rethrow; re-arm interrupt flag on InterruptedException.

🤖 Generated with [Claude Code](https://claude.com/claude-code)