### PR TITLE
Reject HikariConnectionsHealthCheck minConnections <= 0

### DIFF
--- a/cohort-hikari/src/main/kotlin/com/sksamuel/cohort/hikari/HikariConnectionsHealthCheck.kt
+++ b/cohort-hikari/src/main/kotlin/com/sksamuel/cohort/hikari/HikariConnectionsHealthCheck.kt
@@ -18,6 +18,12 @@ class HikariConnectionsHealthCheck(
    override val name: String = "hikari_open_connections",
 ) : HealthCheck {
 
+   init {
+      // Without this guard, minConnections=0 makes the check vacuously healthy (totalConnections
+      // is always >= 0), so a pool that failed to initialize would still report green.
+      require(minConnections > 0) { "minConnections must be > 0, was $minConnections" }
+   }
+
    override suspend fun check(): HealthCheckResult {
       val conns = ds.hikariPoolMXBean.totalConnections
       val msg = "$conns connection(s) to Hikari db-pool ${ds.poolName} [minConnections:$minConnections]"


### PR DESCRIPTION
`totalConnections >= 0` is always true, so `minConnections = 0` makes the check vacuously healthy. Require `> 0` matching the Kafka consumer checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)