### PR TITLE
Wait for in-flight checks to finish on HealthCheckRegistry.close()

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
@@ -278,10 +278,26 @@ class HealthCheckRegistry(
       // invoked from inside the hook, removeShutdownHook throws IllegalStateException because
       // shutdown is in progress — tolerate that.
       runCatching { Runtime.getRuntime().removeShutdownHook(shutdownHook) }
-      scope.cancel()
+      // Order matters: stop the scheduler first so no NEW launches happen, then cancel the
+      // scope and wait for in-flight coroutines to actually finish. The previous order ran
+      // `scope.cancel()` then `scheduler.shutdown()`, leaving a window where a scheduler tick
+      // could still observe an active scope. And `scope.cancel()` is fire-and-forget —
+      // without joining, `close()` returned while real health-check work (JDBC isValid,
+      // HTTP requests on Dispatchers.IO) was still running, racing with the caller's own
+      // resource teardown.
       scheduler.shutdown()
-      runCatching {
+      val schedulerTerminated = runCatching {
          scheduler.awaitTermination(5, TimeUnit.SECONDS)
+      }.getOrDefault(false)
+      if (!schedulerTerminated) logger.warn("Cohort scheduler did not terminate within 5s of close()")
+      // Cancel and join in-flight coroutines so the caller can rely on close() being a barrier.
+      // Bounded by 5s so a misbehaved check can't hang the JVM forever.
+      runCatching {
+         runBlocking {
+            withTimeoutOrNull(5_000) {
+               scope.coroutineContext.job.cancelAndJoin()
+            } ?: logger.warn("Cohort registry coroutines did not terminate within 5s of close()")
+         }
       }
    }
 }


### PR DESCRIPTION
## Summary
- Reorder: shut down the scheduler before \`scope.cancel()\` so no new launches happen after cancellation begins.
- After cancelling, \`runBlocking { withTimeoutOrNull(5s) { scope.job.cancelAndJoin() } }\` so close() actually waits for in-flight check work to finish.
- Log a warning on either timeout.

The previous code returned from \`close()\` while DB/HTTP work was still running, racing with the caller's own resource teardown.

## Test plan
- [ ] Existing tests pass
- [ ] A long-running check finishes (or hits 5s) before close() returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)