### PR TITLE
Mark cross-thread config vars @Volatile for visibility

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/HealthCheckRegistry.kt
@@ -36,9 +36,13 @@ class HealthCheckRegistry(
    private val subscribers = ConcurrentHashMap.newKeySet<Subscriber>()
    private val listeners = ConcurrentHashMap.newKeySet<Listener>()
 
-   var startUnhealthy: Boolean = true
-   var logUnhealthy: Boolean = true
-   var checkTimeout: Duration = 10.seconds
+   // @Volatile so the value written by the configure { } block on the thread that built the
+   // registry is visible to coroutines running on the worker dispatcher. Without it the JMM
+   // does not guarantee a happens-before edge, so checkTimeout could be read as the constructor
+   // default for an indeterminate period.
+   @Volatile var startUnhealthy: Boolean = true
+   @Volatile var logUnhealthy: Boolean = true
+   @Volatile var checkTimeout: Duration = 10.seconds
 
    private val shutdownHook = Thread {
       logger.info("Cohort HealthCheckRegistry shutdown hook is executing")

--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/endpoints/CohortConfiguration.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/endpoints/CohortConfiguration.kt
@@ -40,8 +40,10 @@ class CohortConfiguration {
    // set to true to enable the /cohort/sysprops endpoint which returns current system properties
    var sysprops: Boolean = false
 
-   // set to true to return the detailed status of the healthcheck response
-   var verboseHealthCheckResponse: Boolean = true
+   // set to true to return the detailed status of the healthcheck response.
+   // @Volatile because the field is read from the request-handler thread (Netty event loop /
+   // Vert.x worker) but written from the configure { } block on a different thread.
+   @Volatile var verboseHealthCheckResponse: Boolean = true
 
    var endpointPrefix = "cohort"
 


### PR DESCRIPTION
Plain `var` config fields are written on the construction thread and read from coroutine workers / HTTP handler threads. Without @Volatile, readers can observe the constructor default indefinitely. Mark them @Volatile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)