### PR TITLE
Drop broken .consumes("*")/.produces("*") from Vertx routes

### DIFF
--- a/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
+++ b/cohort-vertx/src/main/kotlin/com/sksamuel/cohort/vertx/vertx.kt
@@ -27,8 +27,6 @@ fun Router.cohort(cohort: CohortConfiguration) {
 
    if (cohort.heapDump) {
       router.get("${cohort.endpointPrefix}/heapdump")
-         .consumes("*")
-         .produces("*")
          .handler { context ->
             getHeapDump().fold(
                {
@@ -43,8 +41,6 @@ fun Router.cohort(cohort: CohortConfiguration) {
 
    if (cohort.memory) {
       router.get("${cohort.endpointPrefix}/memory")
-         .consumes("*")
-         .produces("*")
          .handler { context ->
             getMemoryInfo().fold(
                { context.json(it) },
@@ -56,8 +52,6 @@ fun Router.cohort(cohort: CohortConfiguration) {
    cohort.dataSources.let { dsm ->
       if (dsm.isNotEmpty()) {
          router.get("${cohort.endpointPrefix}/datasources")
-            .consumes("*")
-            .produces("*")
             .handler { context ->
                dsm.map { it.info() }.sequence().fold(
                   { context.json(it) },
@@ -69,8 +63,6 @@ fun Router.cohort(cohort: CohortConfiguration) {
 
    cohort.migrations?.let { m ->
       router.get("${cohort.endpointPrefix}/dbmigration")
-         .consumes("*")
-         .produces("*")
          .handler { context ->
             m.migrations().fold(
                { context.json(it) },
@@ -82,8 +74,6 @@ fun Router.cohort(cohort: CohortConfiguration) {
    cohort.logManager?.let { manager ->
 
       router.get("${cohort.endpointPrefix}/logging")
-         .consumes("*")
-         .produces("*")
          .handler { context ->
             runCatching {
                val levels = manager.levels()
@@ -96,8 +86,6 @@ fun Router.cohort(cohort: CohortConfiguration) {
          }
 
       router.put("${cohort.endpointPrefix}/logging/{name}/{level}")
-         .consumes("*")
-         .produces("*")
          .handler { context ->
             val name = context.pathParam("name")
             val level = context.pathParam("level")
@@ -114,8 +102,6 @@ fun Router.cohort(cohort: CohortConfiguration) {
 
    if (cohort.jvmInfo) {
       router.get("${cohort.endpointPrefix}/jvm")
-         .consumes("*")
-         .produces("*")
          .handler { context ->
             getJvmDetails().fold(
                { context.json(it) },
@@ -126,8 +112,6 @@ fun Router.cohort(cohort: CohortConfiguration) {
 
    if (cohort.gc) {
       router.get("${cohort.endpointPrefix}/gc")
-         .consumes("*")
-         .produces("*")
          .handler { context ->
             getGcInfo().fold(
                { context.json(it) },
@@ -140,8 +124,6 @@ fun Router.cohort(cohort: CohortConfiguration) {
       val endpoint = "${cohort.endpointPrefix}/threaddump"
       logger.debug("Deploying threadDump endpoint at $endpoint")
       router.get(endpoint)
-         .consumes("*")
-         .produces("*")
          .handler { context ->
             getThreadDump().fold(
                { context.response().end(it) },
@@ -154,8 +136,6 @@ fun Router.cohort(cohort: CohortConfiguration) {
       val endpoint = "${cohort.endpointPrefix}/sysprops"
       logger.debug("Deploying sysprops endpoint at $endpoint")
       router.get(endpoint)
-         .consumes("*")
-         .produces("*")
          .handler { context ->
             getSysProps().fold(
                { context.json(it) },
@@ -168,8 +148,6 @@ fun Router.cohort(cohort: CohortConfiguration) {
       val endpoint = "${cohort.endpointPrefix}/os"
       logger.debug("Deploying operatingSystem endpoint at $endpoint")
       router.get(endpoint)
-         .consumes("*")
-         .produces("*")
          .handler { context ->
             getOperatingSystem().fold(
                { context.json(it) },
@@ -182,8 +160,6 @@ fun Router.cohort(cohort: CohortConfiguration) {
       logger.debug("Deploying healthcheck at $endpoint")
 
       router.get(endpoint)
-         .consumes("*")
-         .produces("*")
          .handler { context ->
 
             val status = registry.status()


### PR DESCRIPTION
## Summary
Vert.x's MIME parser treats \`\"*\"\` as \`component=\"*\"\`, \`subComponent=\"\"\` — and the matcher's subComponent check fails for \`Accept: application/json\` against \`\"\"\`. Result: every Vert.x cohort endpoint returns **406 Not Acceptable** to any client that sets an explicit Accept header. Probes (no Accept header) passed and masked the bug.

Drop the calls — unconfigured routes accept any media type, which is what was wanted.

## Test plan
- [ ] \`curl -H 'Accept: application/json' /cohort/healthcheck\` now returns 200/503 instead of 406

🤖 Generated with [Claude Code](https://claude.com/claude-code)