### PR TITLE
Make /cohort/datasources partial-success instead of all-or-nothing

### DIFF
--- a/cohort-ktor/src/main/kotlin/com/sksamuel/cohort/endpoints/endpoints.kt
+++ b/cohort-ktor/src/main/kotlin/com/sksamuel/cohort/endpoints/endpoints.kt
@@ -48,16 +48,13 @@ fun Route.cohort(configure: CohortConfiguration.() -> Unit = {}) {
    config.dataSources.let { dsm ->
       if (dsm.isNotEmpty()) {
          get("${config.endpointPrefix}/datasources") {
-            dsm.map { it.info() }.sequence().fold(
-               { call.respondText(it.toJson(), ContentType.Application.Json, HttpStatusCode.OK) },
-               {
-                  call.respondText(
-                     it.stackTraceToString(),
-                     ContentType.Text.Plain,
-                     HttpStatusCode.InternalServerError
-                  )
-               }
-            )
+            // Return per-pool results. Previously the endpoint called `.sequence()` which
+            // collapses to a single Result.failure if ANY pool fails — operators trying to
+            // diagnose one broken pool lost visibility into the other healthy ones.
+            // `getOrNull()` returns null for failed pools so the JSON shape includes them
+            // explicitly rather than silently dropping; succeeds with 200 always.
+            val infos = dsm.map { it.info().getOrNull() }
+            call.respondText(infos.toJson(), ContentType.Application.Json, HttpStatusCode.OK)
          }
       }
    }

--- a/cohort-ktor/src/main/kotlin/com/sksamuel/cohort/endpoints/json.kt
+++ b/cohort-ktor/src/main/kotlin/com/sksamuel/cohort/endpoints/json.kt
@@ -29,6 +29,9 @@ fun List<ResultJson>.toJson(): String = mapper.writeValueAsString(this)
 @JvmName("DataSourceInfoToJson")
 fun List<DataSourceInfo>.toJson(): String = mapper.writeValueAsString(this)
 
+@JvmName("NullableDataSourceInfoToJson")
+fun List<DataSourceInfo?>.toJson(): String = mapper.writeValueAsString(this)
+
 @JvmName("MigrationToJson")
 fun List<Migration>.toJson(): String = mapper.writeValueAsString(this)
 


### PR DESCRIPTION
`.sequence()` collapsed N pool results into one — any single pool failure took the whole endpoint down with 500, hiding the rest. Return per-pool nullables so partial visibility is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)