### PR TITLE
Replace 5s sleep + zero assertions in HikariConnectionsHealthCheckTest

### DIFF
--- a/cohort-hikari/src/test/kotlin/com/sksamuel/cohort/hikari/HikariConnectionsHealthCheckTest.kt
+++ b/cohort-hikari/src/test/kotlin/com/sksamuel/cohort/hikari/HikariConnectionsHealthCheckTest.kt
@@ -1,26 +1,41 @@
 package com.sksamuel.cohort.hikari
 
 import com.sksamuel.cohort.HealthCheckRegistry
+import com.sksamuel.cohort.HealthStatus
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
+import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.Dispatchers
+import java.util.UUID
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class HikariConnectionsHealthCheckTest : FunSpec({
 
-   test("HealthCheckRegistry should terminate") {
+   test("registry runs the hikari connection check and terminates cleanly") {
       val dataSource = createHikariDS()
       val registry = createHealthChecks(dataSource)
-      Thread.sleep(5000) // let the healthcheck run a few times
-      dataSource.close()
-      registry.close()
+      try {
+         // Force at least one round of checks via an eventually-style assertion, instead of
+         // a 5s Thread.sleep with no assertions.
+         eventually(5.seconds) {
+            val status = registry.status()
+            status.healthchecks.values.firstOrNull()?.result?.status shouldBe HealthStatus.Healthy
+         }
+      } finally {
+         registry.close()
+         dataSource.close()
+      }
    }
 })
 
+// Top-level helpers — also used by HikariPendingThreadsHealthCheckTest.
 fun createHikariDS(): HikariDataSource =
    HikariConfig().apply {
-      jdbcUrl = "jdbc:h2:mem:kjs;DB_CLOSE_DELAY=-1"
+      // Unique DB name per call so DB_CLOSE_DELAY=-1 doesn't share state across specs/tests.
+      jdbcUrl = "jdbc:h2:mem:${UUID.randomUUID()};DB_CLOSE_DELAY=-1"
       username = "sa"
       password = ""
       maximumPoolSize = 1
@@ -28,5 +43,5 @@ fun createHikariDS(): HikariDataSource =
 
 fun createHealthChecks(ds: HikariDataSource): HealthCheckRegistry =
    HealthCheckRegistry(Dispatchers.Default) {
-      register(HikariConnectionsHealthCheck(ds, 1), 1.seconds)
+      register(HikariConnectionsHealthCheck(ds, 1), 100.milliseconds, 100.milliseconds)
    }


### PR DESCRIPTION
Test had a 5s `Thread.sleep` with no assertions, and shared an H2 `mem:kjs` DB across tests. Rewrite with `eventually(5.seconds)` + per-invocation UUID DB + close in finally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)