### PR TITLE
Fix duplicated callCount assertion in HealthCheckRegistryTest

### DIFF
--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/HealthCheckRegistryTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/HealthCheckRegistryTest.kt
@@ -69,7 +69,7 @@ class HealthCheckRegistryTest : FunSpec({
       }
 
       check1.callCount.get() shouldBeGreaterThan 1
-      check1.callCount.get() shouldBeGreaterThan 1
+      check3.callCount.get() shouldBeGreaterThan 1
 
       //Unblock the slow 2nd check
       check2.blocker.set(false)


### PR DESCRIPTION
Two adjacent lines asserted `check1.callCount > 1`. The second was clearly meant to be `check3` — the test claims to verify a slow check2 doesn't block the others, but as written would pass even if check3 never ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)