### PR TITLE
Skip Unix-specific OpenFileDescriptors tests on non-Unix JVMs

### DIFF
--- a/cohort-api/src/test/kotlin/com/sksamuel/cohort/system/OpenFileDescriptorsHealthCheckTest.kt
+++ b/cohort-api/src/test/kotlin/com/sksamuel/cohort/system/OpenFileDescriptorsHealthCheckTest.kt
@@ -8,7 +8,10 @@ import java.lang.management.ManagementFactory
 
 class OpenFileDescriptorsHealthCheckTest : FunSpec({
 
-   val bean = ManagementFactory.getOperatingSystemMXBean() as UnixOperatingSystemMXBean
+   // The MX bean is only a UnixOperatingSystemMXBean on Unix-style JVMs. The previous
+   // top-level `as` cast threw ClassCastException at spec-init time on Windows JVMs,
+   // failing the entire spec — not just the tests that need the bean.
+   val unixBean = ManagementFactory.getOperatingSystemMXBean() as? UnixOperatingSystemMXBean
 
    test("returns healthy when open count is below threshold") {
       OpenFileDescriptorsHealthCheck(Int.MAX_VALUE).check().status shouldBe HealthStatus.Healthy
@@ -19,14 +22,15 @@ class OpenFileDescriptorsHealthCheckTest : FunSpec({
       OpenFileDescriptorsHealthCheck(0).check().status shouldBe HealthStatus.Unhealthy
    }
 
-   test("returns healthy when open count exactly equals threshold") {
-      // verifies <= semantics: equal-to-threshold is healthy, not unhealthy
-      val actual = bean.openFileDescriptorCount.toInt()
-      OpenFileDescriptorsHealthCheck(actual).check().status shouldBe HealthStatus.Healthy
-   }
+   test("returns healthy when open count exactly equals threshold")
+      .config(enabled = unixBean != null) {
+         val actual = unixBean!!.openFileDescriptorCount.toInt()
+         OpenFileDescriptorsHealthCheck(actual).check().status shouldBe HealthStatus.Healthy
+      }
 
-   test("returns unhealthy when threshold is one below current open count") {
-      val actual = bean.openFileDescriptorCount.toInt()
-      OpenFileDescriptorsHealthCheck(actual - 1).check().status shouldBe HealthStatus.Unhealthy
-   }
+   test("returns unhealthy when threshold is one below current open count")
+      .config(enabled = unixBean != null) {
+         val actual = unixBean!!.openFileDescriptorCount.toInt()
+         OpenFileDescriptorsHealthCheck(actual - 1).check().status shouldBe HealthStatus.Unhealthy
+      }
 })


### PR DESCRIPTION
Top-level `as UnixOperatingSystemMXBean` cast threw ClassCastException on Windows, failing the whole spec. Use `as?` + per-test `config(enabled = ...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)