### PR TITLE
Fix memory endpoint serialization failure on JDK 17+ (#50)

### DIFF
--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/FreememHealthCheck.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/FreememHealthCheck.kt
@@ -2,8 +2,6 @@ package com.sksamuel.cohort.memory
 
 import com.sksamuel.cohort.HealthCheck
 import com.sksamuel.cohort.HealthCheckResult
-import java.lang.management.BufferPoolMXBean
-import java.lang.management.MemoryPoolMXBean
 
 /**
  * A Cohort [HealthCheck] that checks free memory in the system.
@@ -31,5 +29,31 @@ class FreememHealthCheck(private val minFreeBytes: Long) : HealthCheck {
   }
 }
 
+data class MemoryInfo(
+  val memoryPools: List<MemoryPool>,
+  val bufferPools: List<BufferPool>,
+)
 
-data class MemoryInfo(val memoryPools: List<MemoryPoolMXBean>, val bufferPools: List<BufferPoolMXBean>)
+data class MemoryPool(
+  val name: String,
+  val type: String,
+  val usage: MemoryUsage?,
+  val peakUsage: MemoryUsage?,
+  val collectionUsage: MemoryUsage?,
+  val memoryManagerNames: List<String>,
+  val valid: Boolean,
+)
+
+data class BufferPool(
+  val name: String,
+  val count: Long,
+  val memoryUsed: Long,
+  val totalCapacity: Long,
+)
+
+data class MemoryUsage(
+  val init: Long,
+  val used: Long,
+  val committed: Long,
+  val max: Long,
+)

--- a/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/GetMemoryInfo.kt
+++ b/cohort-api/src/main/kotlin/com/sksamuel/cohort/memory/GetMemoryInfo.kt
@@ -2,9 +2,35 @@ package com.sksamuel.cohort.memory
 
 import java.lang.management.BufferPoolMXBean
 import java.lang.management.ManagementFactory
+import java.lang.management.MemoryPoolMXBean
+import java.lang.management.MemoryUsage as JavaMemoryUsage
 
 fun getMemoryInfo(): Result<MemoryInfo> = runCatching {
-  val memoryPools = ManagementFactory.getMemoryPoolMXBeans()
-  val bufferPools = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean::class.java)
+  val memoryPools = ManagementFactory.getMemoryPoolMXBeans().map { it.toMemoryPool() }
+  val bufferPools = ManagementFactory.getPlatformMXBeans(BufferPoolMXBean::class.java).map { it.toBufferPool() }
   MemoryInfo(memoryPools, bufferPools)
 }
+
+private fun MemoryPoolMXBean.toMemoryPool(): MemoryPool = MemoryPool(
+  name = name,
+  type = type.name,
+  usage = runCatching { usage }.getOrNull()?.toMemoryUsage(),
+  peakUsage = runCatching { peakUsage }.getOrNull()?.toMemoryUsage(),
+  collectionUsage = runCatching { collectionUsage }.getOrNull()?.toMemoryUsage(),
+  memoryManagerNames = memoryManagerNames.toList(),
+  valid = isValid,
+)
+
+private fun BufferPoolMXBean.toBufferPool(): BufferPool = BufferPool(
+  name = name,
+  count = count,
+  memoryUsed = memoryUsed,
+  totalCapacity = totalCapacity,
+)
+
+private fun JavaMemoryUsage.toMemoryUsage(): MemoryUsage = MemoryUsage(
+  init = init,
+  used = used,
+  committed = committed,
+  max = max,
+)

--- a/cohort-ktor/src/test/kotlin/com/sksamuel/cohort/memory/MemoryInfoSerializationTest.kt
+++ b/cohort-ktor/src/test/kotlin/com/sksamuel/cohort/memory/MemoryInfoSerializationTest.kt
@@ -1,0 +1,15 @@
+package com.sksamuel.cohort.memory
+
+import com.sksamuel.cohort.endpoints.toJson
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.string.shouldContain
+
+class MemoryInfoSerializationTest : FunSpec({
+
+   test("MemoryInfo from live MXBeans serializes to JSON without reflection errors (issue #50)") {
+      val info = getMemoryInfo().getOrThrow()
+      val json = info.toJson()
+      json shouldContain "memoryPools"
+      json shouldContain "bufferPools"
+   }
+})


### PR DESCRIPTION
## Summary
- Fixes #50: `/cohort/memory` threw `InaccessibleObjectException` on JDK 17+ because Jackson tried to reflect into `sun.management.MemoryPoolImpl`, which `java.management` does not open to unnamed modules.
- `MemoryInfo` now exposes plain data classes (`MemoryPool`, `BufferPool`, `MemoryUsage`) instead of the raw `MemoryPoolMXBean` / `BufferPoolMXBean` interfaces, mirroring how `GCInfo` already handles `GarbageCollectorMXBean`.
- `getMemoryInfo()` maps each MXBean to its data-class equivalent, guarding the optional `usage` / `peakUsage` / `collectionUsage` accessors that can throw on some pools.

## Test plan
- [x] `./gradlew build -x test` — all modules compile.
- [x] `./gradlew :cohort-api:test` — existing tests pass.
- [x] New `MemoryInfoSerializationTest` in `cohort-ktor` exercises live MXBeans → `MemoryInfo` → JSON, which would have reproduced the reported exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)